### PR TITLE
Fixed bug in build order system

### DIFF
--- a/AssemblyManager.cpp
+++ b/AssemblyManager.cpp
@@ -459,17 +459,18 @@ bool CUNYAIModule::Building_Begin(const Unit &drone, const Inventory &inv, const
         u_loc = getUnitInventoryInRadius(friendly_player_model.units_, drone->getPosition(), inv.my_portion_of_the_map_);
     }
 
-    // Trust the build order. If there is a build order and it wants a building, build it!
+	// Trust the build order. If there is a build order and it wants a building, build it!
 	if (!buildorder.isEmptyBuildOrder()) {
 		UnitType next_in_build_order = buildorder.building_gene_.front().getUnit();
-		if (!buildings_started) buildings_started = Check_N_Build(next_in_build_order, drone, false);
+		if (next_in_build_order == UnitTypes::Zerg_Hatchery) buildings_started = Expo(drone, false, inventory);
+		else buildings_started = Check_N_Build(next_in_build_order, drone, false);
 	}
 
     //Macro-related Buildings.
-    if( !buildings_started) buildings_started = Expo(drone, (!army_starved || enemy_player_model.units_.moving_average_fap_stock_<= friendly_player_model.units_.moving_average_fap_stock_ || expansion_vital) && (expansion_meaningful || larva_starved || econ_starved), inventory);
+    if( !buildings_started ) buildings_started = Expo(drone, (!army_starved || enemy_player_model.units_.moving_average_fap_stock_<= friendly_player_model.units_.moving_average_fap_stock_ || expansion_vital) && (expansion_meaningful || larva_starved || econ_starved), inventory);
     //buildings_started = expansion_meaningful; // stop if you need an expo!
-    if( !buildings_started) buildings_started = Check_N_Build(UnitTypes::Zerg_Hatchery, drone, larva_starved && inv.min_workers_ + inv.gas_workers_ > inv.hatches_ * 5); // only macrohatch if you are short on larvae and can afford to spend.
-
+    if( !buildings_started ) buildings_started = Check_N_Build(UnitTypes::Zerg_Hatchery, drone, larva_starved && inv.min_workers_ + inv.gas_workers_ > inv.hatches_ * 5); // only macrohatch if you are short on larvae and can afford to spend.
+	
     if( !buildings_started) buildings_started = Check_N_Build(UnitTypes::Zerg_Extractor, drone,
         (inv.gas_workers_ >= 2 * (Count_Units(UnitTypes::Zerg_Extractor, inv) - Broodwar->self()->incompleteUnitCount(UnitTypes::Zerg_Extractor)) && gas_starved) &&
         Broodwar->self()->incompleteUnitCount(UnitTypes::Zerg_Extractor) == 0);  // wait till you have a spawning pool to start gathering gas. If your gas is full (or nearly full) get another extractor.  Note that gas_workers count may be off. Sometimes units are in the gas geyser.

--- a/GeneticHistoryManager.cpp
+++ b/GeneticHistoryManager.cpp
@@ -425,13 +425,13 @@ GeneticHistory::GeneticHistory(string file) {
 
 	// Overwrite whatever you previously wanted if we're using "test mode".
 	if constexpr (TEST_MODE) {
-		// Values taken from print file (10/3/18)
+		// Values altered 
 		delta_out_mutate_ = 0.3021355;
-		gamma_out_mutate_ = 0.279526;
+		gamma_out_mutate_ = 0.35;
 		a_army_out_mutate_ = 0.511545;
 		a_econ_out_mutate_ = 0.488455;
 		a_tech_out_mutate_ = 0.52895;
 		r_out_mutate_ = 0.5097605;
-		build_order_ = "drone drone drone drone drone pool drone extract overlord drone ling ling ling ling ling ling hydra_den drone drone drone drone";
+		build_order_ = "drone drone drone drone overlord drone drone drone hatch pool drone extract drone drone drone drone drone drone hydra_den drone overlord drone drone drone grooved_spines hydra hydra hydra hydra hydra hydra hydra overlord hydra hydra hydra hydra hydra hatch extract"; //zerg_2hatchhydra -range added an overlord.
 	}
 }

--- a/InventoryManager.cpp
+++ b/InventoryManager.cpp
@@ -734,9 +734,10 @@ bool Inventory::checkViableGroundPath(const Position A, const Position B) const
     }
 return false;
 }
+
 int Inventory::getRadialDistanceOutFromHome( const Position A ) const
 {
-    if (map_out_from_enemy_ground_.size() > 0 && A.isValid()) {
+    if (map_out_from_home_.size() > 0 && A.isValid()) {
         WalkPosition wp_a = WalkPosition(A);
         int A = map_out_from_home_[(size_t)wp_a.x][(size_t)wp_a.y];
         if (A > 1) {

--- a/MiningManager.cpp
+++ b/MiningManager.cpp
@@ -32,6 +32,7 @@ bool CUNYAIModule::Expo( const Unit &unit, const bool &extra_critera, Inventory 
                 if ( (dist_temp < dist || expansion_is_home) && safe_expo && !occupied_expo) {
                     dist = dist_temp;
                     inv.setNextExpo( p );
+					CUNYAIModule::DiagnosticText("Found an expo at ( %d , %d )", inv.next_expo_.x, inv.next_expo_.y);
                 }
             }
         }

--- a/Source/CUNYAIModule.h
+++ b/Source/CUNYAIModule.h
@@ -14,7 +14,7 @@
 
 constexpr bool RESIGN_MODE = false; // must be off for proper game close in SC-docker
 constexpr bool ANALYSIS_MODE = true; // Printing records, etc.
-constexpr bool DRAWING_MODE = false; // Visualizations, printing records, etc. Should seperate these.
+constexpr bool DRAWING_MODE = true; // Visualizations, printing records, etc. Should seperate these.
 constexpr bool MOVE_OUTPUT_BACK_TO_READ = false; // should be OFF for sc-docker, ON for chaoslauncher at home & Training against base ai.
 constexpr bool SSCAIT_OR_DOCKER = true; // should be ON for SC-docker, ON for SSCAIT.
 constexpr bool LEARNING_MODE = true; //if we are exploring new positions or simply keeping existing ones.  Should almost always be on. If off, prevents both mutation and interbreeding of parents, they will only clone themselves.


### PR DESCRIPTION
Causing build order hatcheries to always be built as macro hatches, when they -never- ought to be.