### PR TITLE
ScoutingManager v1

### DIFF
--- a/CUNYAIModule.vcxproj
+++ b/CUNYAIModule.vcxproj
@@ -1,4 +1,4 @@
- <?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">

--- a/CUNYAIModule.vcxproj
+++ b/CUNYAIModule.vcxproj
@@ -15,7 +15,7 @@
     <RootNamespace>ExampleAIModule</RootNamespace>
     <Keyword>Win32Proj</Keyword>
     <ProjectName>CUNYAIModule</ProjectName>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
@@ -102,6 +102,7 @@
     <ClCompile Include="Research_Inventory.cpp" />
     <ClCompile Include="Reserve_Manager.cpp" />
     <ClCompile Include="Resource_Inventory.cpp" />
+    <ClCompile Include="ScoutingManager.cpp" />
     <ClCompile Include="Source\CUNYAIModule.cpp" />
     <ClCompile Include="Unit_Inventory.cpp" />
     <ClCompile Include="GeneticHistoryManager.cpp" />
@@ -122,6 +123,7 @@
     <ClInclude Include="Source\Research_Inventory.h" />
     <ClInclude Include="Source\Reservation_Manager.h" />
     <ClInclude Include="Source\Resource_Inventory.h" />
+    <ClInclude Include="Source\ScoutingManager.h" />
     <ClInclude Include="Source\Unit_Inventory.h" />
     <ClInclude Include="Source\GeneticHistoryManager.h" />
   </ItemGroup>

--- a/CUNYAIModule.vcxproj
+++ b/CUNYAIModule.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+ <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -15,7 +15,7 @@
     <RootNamespace>ExampleAIModule</RootNamespace>
     <Keyword>Win32Proj</Keyword>
     <ProjectName>CUNYAIModule</ProjectName>
-    <WindowsTargetPlatformVersion>10.0.17134.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">

--- a/CUNYAIModule.vcxproj.filters
+++ b/CUNYAIModule.vcxproj.filters
@@ -45,6 +45,9 @@
     <ClCompile Include="Map_Inventory.cpp">
       <Filter>Utilities</Filter>
     </ClCompile>
+    <ClCompile Include="ScoutingManager.cpp">
+      <Filter>Utilities</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Source\CobbDouglas.h" />
@@ -58,6 +61,7 @@
     <ClInclude Include="Source\Research_Inventory.h" />
     <ClInclude Include="Source\PlayerModelManager.h" />
     <ClInclude Include="Source\Map_Inventory.h" />
+    <ClInclude Include="Source\ScoutingManager.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Utilities">

--- a/Map_Inventory.cpp
+++ b/Map_Inventory.cpp
@@ -1706,7 +1706,7 @@ Position Map_Inventory::getMeanEnemyBuildingLocation(Unit_Inventory &ei) const {
 	Position out = Positions::Origin;
 	for (auto e : ei.unit_inventory_) {
 		UnitType e_type = e.second.type_;
-		if (e_type.isBuilding() && (!e_type.isResourceDepot() && !e_type.isRefinery())) { // Scout for tech buildings, don't care about expos or refineries
+		if (e_type.isBuilding()) { // Scout for tech buildings, don't care about expos or refineries
 			x_sum += e.second.pos_.x;
 			y_sum += e.second.pos_.y;
 			count++;

--- a/Map_Inventory.cpp
+++ b/Map_Inventory.cpp
@@ -1696,3 +1696,24 @@ vector<int> Map_Inventory::getRadialDistances(const Unit_Inventory & ui, const v
 
     return return_vector = { 0 };
 }
+
+Position Map_Inventory::getMeanEnemyBuildingLocation(Unit_Inventory &ei) const {
+// Potentially large overhead? 
+// Cycling through every enemy unit, could split into storing enemy buildings and only updating instead
+	int x_sum = 0;
+	int y_sum = 0;
+	int count = 0;
+	Position out = Positions::Origin;
+	for (auto e : ei.unit_inventory_) {
+		UnitType e_type = e.second.type_;
+		if (e_type.isBuilding() && (!e_type.isResourceDepot() && !e_type.isRefinery())) { // Scout for tech buildings, don't care about expos or refineries
+			x_sum += e.second.pos_.x;
+			y_sum += e.second.pos_.y;
+			count++;
+		}
+	}
+	if (count > 0) {
+		out = Position(x_sum / count, y_sum / count);
+	}
+	return out;
+}

--- a/PlayerModelManager.cpp
+++ b/PlayerModelManager.cpp
@@ -8,6 +8,18 @@
 using namespace std;
 using namespace BWAPI;
 
+void Player_Model::gameStartConditions() {
+// Starting conditions for the game based off enemy race, etc
+// Will only be called once upon game start
+	Race enemyRace = Broodwar->enemy()->getRace();
+
+	// Don't let overlords scout against terran. Currently the only modification to AI based off race.
+	if (enemyRace == Races::Terran) {
+		ScoutingManager scouting;
+		scouting.let_overlords_scout_ = false;
+	}
+}
+
 void Player_Model::updateOtherOnFrame(const Player & other_player)
 {
     bwapi_player_ = other_player;

--- a/ScoutingManager.cpp
+++ b/ScoutingManager.cpp
@@ -32,8 +32,11 @@ Position ScoutingManager::getScoutTargets(const Unit &unit, Map_Inventory &inv, 
 
 	// Get the mean enemy base location if we have found the enemy base
 	if (inv.getMeanEnemyBuildingLocation(ei) != Positions::Origin) {
-		e_base_scout = CUNYAIModule::getClosestGroundStored(ei, inv.getMeanEnemyBuildingLocation(ei), inv)->pos_;
-		found_enemy_base_ = true;
+		Stored_Unit* nearest_building = CUNYAIModule::getClosestGroundStored(ei, inv.getMeanEnemyBuildingLocation(ei), inv);
+		if (nearest_building != nullptr) {
+			e_base_scout = nearest_building->pos_;
+			found_enemy_base_ = true;
+		}
 	}
 	
 	// If we haven't found any enemy buildings yet

--- a/ScoutingManager.cpp
+++ b/ScoutingManager.cpp
@@ -28,8 +28,11 @@ ScoutingManager::ScoutingManager()
 Position ScoutingManager::getScoutTargets(const Unit &unit, Map_Inventory &inv, Unit_Inventory &ei) {
 // Scouting priorities
 	Position scout_spot;
-	Position e_base_scout = inv.getMeanEnemyBuildingLocation(ei);
-	found_enemy_base_ = (e_base_scout != Positions::Origin);
+
+	if (inv.getMeanEnemyBuildingLocation(ei) != Positions::Origin) {
+		Position e_base_scout = CUNYAIModule::getClosestGroundStored(ei, inv.getMeanEnemyBuildingLocation(ei), inv)->pos_;
+		found_enemy_base_ = true;
+	}
 	
 	// If we haven't found any enemy buildings yet
 	if (!found_enemy_base_) {
@@ -47,6 +50,8 @@ Position ScoutingManager::getScoutTargets(const Unit &unit, Map_Inventory &inv, 
 
 	// Found an enemy building
 	if (found_enemy_base_) {
+
+		Position e_base_scout = CUNYAIModule::getClosestGroundStored(ei, inv.getMeanEnemyBuildingLocation(ei), inv)->pos_;
 		
 		// Suicide zergling or an overlord scout
 		if (zergling_scout_ == unit || overlord_scout_ == unit) { 
@@ -106,6 +111,10 @@ bool ScoutingManager::needScout(const Unit &unit, const int &t_game) const {
 void ScoutingManager::updateScouts() {
 // Check if scouts have died
 
+	//if (CUNYAIModule::getMostAdvancedThreatOrTargetStored(ui, unit, inv, 256)) {
+	//	clearScout(unit);
+	//	return false;
+	//}
 	//if we thought we had a suicide zergling scout but now we don't
 	if (zergling_scout_ != nullptr) {
 		if (!zergling_scout_->exists()) {

--- a/ScoutingManager.cpp
+++ b/ScoutingManager.cpp
@@ -148,10 +148,13 @@ void ScoutingManager::updateScouts() {
 void ScoutingManager::setScout(const Unit &unit, const int &ling_type) {
 // Store unit as a designated scout
 	UnitType u_type = unit->getType();
+	Stored_Unit& scout_unit = CUNYAIModule::friendly_player_model.units_.unit_inventory_.find(unit)->second;
+	scout_unit.updateStoredUnit(unit);
 	// Set overlord as a scout
 	if (u_type == UnitTypes::Zerg_Overlord) {
 		overlord_scout_ = unit;
 		exists_overlord_scout_ = true;
+		scout_unit.phase_ = "Scouting";
 		return;
 	}
 
@@ -161,12 +164,14 @@ void ScoutingManager::setScout(const Unit &unit, const int &ling_type) {
 		if (ling_type == 1) {
 			expo_zergling_scout_ = unit;
 			exists_expo_zergling_scout_ = true;
+			scout_unit.phase_ = "Scouting";
 			return;
 		}
 		// suicide scout
 		if (ling_type == 2) {
 			zergling_scout_ = unit;
 			exists_zergling_scout_ = true;
+			scout_unit.phase_ = "Scouting";
 			return;
 		}
 	}

--- a/ScoutingManager.cpp
+++ b/ScoutingManager.cpp
@@ -1,0 +1,107 @@
+#pragma once
+
+#include "Source\ScoutingManager.h"
+
+ScoutingManager::ScoutingManager() {
+	int _last_overlord_scout_sent(0);
+	int _last_zergling_scout_sent(0);
+	bool _exists_zergling_scout(false);
+	bool _exists_overlord_scout(false);
+	bool _let_overlords_scout(true);
+	Unit _overlord_scout(nullptr);
+	Unit _zergling_scout(nullptr);
+	Unit _last_overlord_scout(nullptr);
+	Unit _last_zergling_scout(nullptr);
+}
+
+// -- Work in progress -- Only scouting starting base locations currently
+Position ScoutingManager::getScoutTargets(const Unit &unit, Map_Inventory &inv, Unit_Inventory &ei) {
+// Scouting priorities
+	Position scout_spot;
+	if (!inv.start_positions_.empty() && find(inv.start_positions_.begin(), inv.start_positions_.end(), unit->getLastCommand().getTargetPosition()) == inv.start_positions_.end()) {
+		scout_spot = inv.start_positions_[0];
+	}
+	return scout_spot;
+}
+
+bool ScoutingManager::needScout(const Unit &unit, const int &t_game) {
+// When do we want to scout
+	UnitType u_type = unit->getType();
+	if (t_game < 5) return true;  // first 5 frames for a buffer. Doing (t_game == 0) sometimes skips sending initial overloard
+
+	// need zergling scout whenever we have zerglings, a scout doesn't exist already, and one hasn't been killed semi-recently
+	if ( u_type == UnitTypes::Zerg_Zergling && !_exists_zergling_scout && (_last_zergling_scout_sent < t_game - Broodwar->getLatencyFrames() - 30 * 24) ) return true;
+
+	if (_let_overlords_scout && !_exists_overlord_scout && _last_overlord_scout_sent < t_game - Broodwar->getLatencyFrames() - 30 * 24) return true;
+	return false;
+}
+
+void ScoutingManager::updateScouts() {
+// Check if scouts have died
+	if (_exists_zergling_scout && !_zergling_scout->exists()) {  //if we thought we had a scout but now we don't
+		_zergling_scout = nullptr;
+		_exists_zergling_scout = false;
+		Broodwar->sendText("Zergling scout died");
+	}
+	if (_exists_overlord_scout && !_overlord_scout->exists()) {  //if we thought we had a scout but now we don't
+		_overlord_scout = nullptr;
+		_exists_overlord_scout = false;
+		Broodwar->sendText("Overlord scout died");
+	}
+}
+
+void ScoutingManager::setScout(const Unit &unit) {
+// Store unit as a designated scout
+	UnitType u_type = unit->getType();
+
+	if (u_type == UnitTypes::Zerg_Overlord && _let_overlords_scout) {
+		_overlord_scout = unit;
+		_exists_overlord_scout = true;
+		_last_overlord_scout_sent = Broodwar->getFrameCount(); // Store timer of dead scout
+		Broodwar->sendText("Setting an overlord scout");
+		return;
+	}
+
+	if (u_type == UnitTypes::Zerg_Zergling) {
+		_zergling_scout = unit;
+		_exists_zergling_scout = true;
+		_last_zergling_scout_sent = Broodwar->getFrameCount(); // Store timer of dead scout
+		Broodwar->sendText("Setting a zergling scout");
+		return;
+	}
+}
+
+void ScoutingManager::clearScout(const Unit &unit) {
+// Clear the unit from scouting duty
+	UnitType u_type = unit->getType();
+
+	if (u_type == UnitTypes::Zerg_Overlord && isScoutingUnit(unit) && _overlord_scout->exists()) {
+		_last_overlord_scout = unit; // Keep track of the cleared scout if still exists
+		_overlord_scout = nullptr;
+		_exists_overlord_scout = false;
+		_last_overlord_scout_sent = Broodwar->getFrameCount(); // Store timer of dead scout
+		Broodwar->sendText("Scout cleared");
+	}
+
+	if (u_type == UnitTypes::Zerg_Zergling && isScoutingUnit(unit) && _zergling_scout->exists()) {
+		_last_zergling_scout = unit;   // Keep track of the cleared scout if still exists
+		_zergling_scout = nullptr;
+		_exists_zergling_scout = false;
+		_last_zergling_scout_sent = Broodwar->getFrameCount(); // Store timer of dead scout
+		Broodwar->sendText("Scout cleared");
+	}
+}
+
+bool ScoutingManager::isScoutingUnit(const Unit &unit) {
+// Check if a particular unit is a designated scout
+	if (_overlord_scout == unit || _zergling_scout == unit) return true;
+
+	return false;
+}
+
+// -- Work in progress --
+void ScoutingManager::sendScout(const Unit &unit, const Position &scout_spot) {
+// Move the scout to the assigned scouting location
+	unit->move(scout_spot);
+	Broodwar->sendText("Scout Sent");
+}

--- a/ScoutingManager.cpp
+++ b/ScoutingManager.cpp
@@ -134,9 +134,9 @@ void ScoutingManager::updateScouts() {
 // Check if scouts have died
 
 	//if we thought we had a suicide zergling scout but now we don't
-	if (zergling_scout_ != nullptr) {
+	if (zergling_scout_) {
 		if (!zergling_scout_->exists()) {
-			zergling_scout_ = 0;
+			zergling_scout_ = nullptr;
 			exists_zergling_scout_ = false;
 			last_zergling_scout_sent_ = Broodwar->getFrameCount();
 			Broodwar->sendText("Zergling scout died");
@@ -144,18 +144,18 @@ void ScoutingManager::updateScouts() {
 	}
 
 	//if we thought we had an expo zergling scout but now we don't
-	if (expo_zergling_scout_ != nullptr) {
+	if (expo_zergling_scout_) {
 		if (!expo_zergling_scout_->exists()) {
-			expo_zergling_scout_ = 0;
+			expo_zergling_scout_ = nullptr;
 			exists_expo_zergling_scout_ = false;
 			Broodwar->sendText("Expo ling scout died");
 		}
 	}
 
 	//if we thought we had an overlord scout but now we don't
-	if (overlord_scout_ != nullptr) {
-		if (!overlord_scout_->exists()) {  //if we thought we had a scout but now we don't
-			overlord_scout_ = 0;
+	if (overlord_scout_) {
+		if (!overlord_scout_->exists()) { 
+			overlord_scout_ = nullptr;
 			exists_overlord_scout_ = false;
 			last_overlord_scout_sent_ = Broodwar->getFrameCount();
 			Broodwar->sendText("Overlord scout died");

--- a/Source/CUNYAIModule.cpp
+++ b/Source/CUNYAIModule.cpp
@@ -690,13 +690,10 @@ void CUNYAIModule::onFrame()
         }
         auto end_detector = std::chrono::high_resolution_clock::now();
 
-		// Disable scouting temporarily if we have a massive army to attack or are under threat of being killed
-		bool disable_scouting = ( ((friendly_player_model.units_.stock_fighting_total_ - Stock_Units(UnitTypes::Zerg_Sunken_Colony, friendly_player_model.units_) - Stock_Units(UnitTypes::Zerg_Spore_Colony, friendly_player_model.units_) > enemy_player_model.units_.stock_fighting_total_ * 3) || 
-								(enemy_player_model.units_.stock_fighting_total_ > friendly_player_model.units_.stock_fighting_total_) ) &&
-								 enemy_player_model.units_.stock_fighting_total_ != 0 );  //Make sure we've actually seen enemy stock before disabling scouting
-		if (enemy_player_model.units_.stock_shoots_up_) // If enemy has units that can shoot overlords, stop overlord scouting
+		
+		// If enemy has units that can shoot overlords, stop overlord scouting
+		if (enemy_player_model.units_.stock_shoots_up_)
 			scouting.let_overlords_scout_ = false;
-
 		// Scout Assignment Logic. Before Combat logic so scouts don't attack. Only if scouting isn't disabled
 		if (!disable_scouting) {
 			if ( scouting.needScout(u, t_game) && (!u->isAttacking() && !isRecentCombatant(u)) &&

--- a/Source/CUNYAIModule.cpp
+++ b/Source/CUNYAIModule.cpp
@@ -98,6 +98,9 @@ void CUNYAIModule::onStart()
     econ_starved = true;
     tech_starved = false;
 
+	//Initialize the starting game conditions for our player model (based off enemy race, etc)
+	friendly_player_model.gameStartConditions(); 
+
     //Initialize model variables. 
     GeneticHistory gene_history = GeneticHistory( ".\\bwapi-data\\read\\output.txt" );
 
@@ -1099,18 +1102,18 @@ void CUNYAIModule::onFrame()
         }
     }
 
-    //if constexpr (DRAWING_MODE) {
-    //    int n;
-    //    n = sprintf(delay_string, "Delays:{S:%d,M:%d,L:%d}%3.fms", short_delay, med_delay, long_delay, total_frame_time.count());
-    //    n = sprintf(preamble_string, "Preamble:      %3.f%%,%3.fms ", preamble_time.count() / (double)total_frame_time.count() * 100, preamble_time.count());
-    //    n = sprintf(larva_string, "Larva:         %3.f%%,%3.fms", larva_time.count() / (double)total_frame_time.count() * 100, larva_time.count());
-    //    n = sprintf(worker_string, "Workers:       %3.f%%,%3.fms", worker_time.count() / (double)total_frame_time.count() * 100, worker_time.count());
-    //    n = sprintf(scouting_string, "Scouting:      %3.f%%,%3.fms", scout_time.count() / (double)total_frame_time.count() * 100, scout_time.count());
-    //    n = sprintf(combat_string, "Combat:        %3.f%%,%3.fms", combat_time.count() / (double)total_frame_time.count() * 100, combat_time.count());
-    //    n = sprintf(detection_string, "Detection:     %3.f%%,%3.fms", detector_time.count() / (double)total_frame_time.count() * 100, detector_time.count());
-    //    n = sprintf(upgrade_string, "Upgrades:      %3.f%%,%3.fms", upgrade_time.count() / (double)total_frame_time.count() * 100, upgrade_time.count());
-    //    n = sprintf(creep_colony_string, "CreepColonies: %3.f%%,%3.fms", creepcolony_time.count() / (double)total_frame_time.count() * 100, creepcolony_time.count());
-    //}
+    if constexpr (DRAWING_MODE) {
+        int n;
+        n = sprintf(delay_string, "Delays:{S:%d,M:%d,L:%d}%3.fms", short_delay, med_delay, long_delay, total_frame_time.count());
+        n = sprintf(preamble_string, "Preamble:      %3.f%%,%3.fms ", preamble_time.count() / (double)total_frame_time.count() * 100, preamble_time.count());
+        n = sprintf(larva_string, "Larva:         %3.f%%,%3.fms", larva_time.count() / (double)total_frame_time.count() * 100, larva_time.count());
+        n = sprintf(worker_string, "Workers:       %3.f%%,%3.fms", worker_time.count() / (double)total_frame_time.count() * 100, worker_time.count());
+        n = sprintf(scouting_string, "Scouting:      %3.f%%,%3.fms", scout_time.count() / (double)total_frame_time.count() * 100, scout_time.count());
+        n = sprintf(combat_string, "Combat:        %3.f%%,%3.fms", combat_time.count() / (double)total_frame_time.count() * 100, combat_time.count());
+        n = sprintf(detection_string, "Detection:     %3.f%%,%3.fms", detector_time.count() / (double)total_frame_time.count() * 100, detector_time.count());
+        n = sprintf(upgrade_string, "Upgrades:      %3.f%%,%3.fms", upgrade_time.count() / (double)total_frame_time.count() * 100, upgrade_time.count());
+        n = sprintf(creep_colony_string, "CreepColonies: %3.f%%,%3.fms", creepcolony_time.count() / (double)total_frame_time.count() * 100, creepcolony_time.count());
+    }
 
 } // closure: Onframe
 

--- a/Source/CUNYAIModule.cpp
+++ b/Source/CUNYAIModule.cpp
@@ -293,10 +293,6 @@ void CUNYAIModule::onFrame()
         land_inventory = mineral_inventory + geyser_inventory; // for first initialization.
         current_map_inventory.updateBaseLoc(land_inventory);
         current_map_inventory.getExpoPositions(); // prime this once on game start.
-		
-		// Don't let overlords scout against terran. Currently the only modification to AI based off race.
-		Race enemyRace = Broodwar->enemy()->getRace();
-		if (enemyRace == Races::Terran) scouting.let_overlords_scout_ = false;
     }
 
     current_map_inventory.updateBasePositions(friendly_player_model.units_, enemy_player_model.units_, land_inventory, neutral_player_model.units_, friendly_player_model.casualties_);

--- a/Source/CUNYAIModule.cpp
+++ b/Source/CUNYAIModule.cpp
@@ -1099,18 +1099,18 @@ void CUNYAIModule::onFrame()
         }
     }
 
-    if constexpr (DRAWING_MODE) {
-        int n;
-        n = sprintf(delay_string, "Delays:{S:%d,M:%d,L:%d}%3.fms", short_delay, med_delay, long_delay, total_frame_time.count());
-        n = sprintf(preamble_string, "Preamble:      %3.f%%,%3.fms ", preamble_time.count() / (double)total_frame_time.count() * 100, preamble_time.count());
-        n = sprintf(larva_string, "Larva:         %3.f%%,%3.fms", larva_time.count() / (double)total_frame_time.count() * 100, larva_time.count());
-        n = sprintf(worker_string, "Workers:       %3.f%%,%3.fms", worker_time.count() / (double)total_frame_time.count() * 100, worker_time.count());
-        n = sprintf(scouting_string, "Scouting:      %3.f%%,%3.fms", scout_time.count() / (double)total_frame_time.count() * 100, scout_time.count());
-        n = sprintf(combat_string, "Combat:        %3.f%%,%3.fms", combat_time.count() / (double)total_frame_time.count() * 100, combat_time.count());
-        n = sprintf(detection_string, "Detection:     %3.f%%,%3.fms", detector_time.count() / (double)total_frame_time.count() * 100, detector_time.count());
-        n = sprintf(upgrade_string, "Upgrades:      %3.f%%,%3.fms", upgrade_time.count() / (double)total_frame_time.count() * 100, upgrade_time.count());
-        n = sprintf(creep_colony_string, "CreepColonies: %3.f%%,%3.fms", creepcolony_time.count() / (double)total_frame_time.count() * 100, creepcolony_time.count());
-    }
+    //if constexpr (DRAWING_MODE) {
+    //    int n;
+    //    n = sprintf(delay_string, "Delays:{S:%d,M:%d,L:%d}%3.fms", short_delay, med_delay, long_delay, total_frame_time.count());
+    //    n = sprintf(preamble_string, "Preamble:      %3.f%%,%3.fms ", preamble_time.count() / (double)total_frame_time.count() * 100, preamble_time.count());
+    //    n = sprintf(larva_string, "Larva:         %3.f%%,%3.fms", larva_time.count() / (double)total_frame_time.count() * 100, larva_time.count());
+    //    n = sprintf(worker_string, "Workers:       %3.f%%,%3.fms", worker_time.count() / (double)total_frame_time.count() * 100, worker_time.count());
+    //    n = sprintf(scouting_string, "Scouting:      %3.f%%,%3.fms", scout_time.count() / (double)total_frame_time.count() * 100, scout_time.count());
+    //    n = sprintf(combat_string, "Combat:        %3.f%%,%3.fms", combat_time.count() / (double)total_frame_time.count() * 100, combat_time.count());
+    //    n = sprintf(detection_string, "Detection:     %3.f%%,%3.fms", detector_time.count() / (double)total_frame_time.count() * 100, detector_time.count());
+    //    n = sprintf(upgrade_string, "Upgrades:      %3.f%%,%3.fms", upgrade_time.count() / (double)total_frame_time.count() * 100, upgrade_time.count());
+    //    n = sprintf(creep_colony_string, "CreepColonies: %3.f%%,%3.fms", creepcolony_time.count() / (double)total_frame_time.count() * 100, creepcolony_time.count());
+    //}
 
 } // closure: Onframe
 

--- a/Source/CUNYAIModule.cpp
+++ b/Source/CUNYAIModule.cpp
@@ -684,25 +684,44 @@ void CUNYAIModule::onFrame()
 		// Update scouts, check if still alive.
 		scouting.updateScouts();
 
+		// If enemy has units that can shoot overlords, stop overlord scouting
+		if (enemy_player_model.units_.stock_shoots_up_)
+			scouting.let_overlords_scout_ = false;
+
 		// Scout Assignment Logic. Before Combat logic so scouts don't attack
-		if (scouting.needScout(u, t_game) && (u_type == UnitTypes::Zerg_Overlord || u_type == UnitTypes::Zerg_Zergling)) {
-			Broodwar->sendText("Scouting loop");
-			Position scout_spot = scouting.getScoutTargets(u, current_map_inventory, enemy_player_model.units_);
-			if (u_type == UnitTypes::Zerg_Zergling && !scouting.exists_zergling_scout_) {
-				scouting.setScout(u);
-				scouting.sendScout(u, scout_spot);
-				continue;
+		if ( scouting.needScout(u, t_game) && (!u->isAttacking() || !isRecentCombatant(u)) && 
+		   ((u_type == UnitTypes::Zerg_Overlord && scouting.let_overlords_scout_) || u_type == UnitTypes::Zerg_Zergling) ) {
+
+			// Make zergling into a scout
+			if (u_type == UnitTypes::Zerg_Zergling) {
+				if (!scouting.exists_expo_zergling_scout_) {
+					scouting.setScout(u, 1);
+					Position scout_spot = scouting.getScoutTargets(u, current_map_inventory, enemy_player_model.units_);
+					scouting.sendScout(u, scout_spot);
+					continue;
+				}
+				if (!scouting.exists_zergling_scout_) {
+					scouting.setScout(u, 2);
+					Position scout_spot = scouting.getScoutTargets(u, current_map_inventory, enemy_player_model.units_);
+					scouting.sendScout(u, scout_spot);
+					continue;
+				}
 			}
-			if (u_type == UnitTypes::Zerg_Overlord && !scouting.exists_overlord_scout_) {
+			// Make overlord into a scout
+			if (u_type == UnitTypes::Zerg_Overlord) {
 				scouting.setScout(u);
+				Position scout_spot = scouting.getScoutTargets(u, current_map_inventory, enemy_player_model.units_);
 				scouting.sendScout(u, scout_spot);
 				continue;
 			}
 		}
 		// Scout Clearing Logic
 		if (scouting.isScoutingUnit(u) && (u->isIdle() || (u_type == UnitTypes::Zerg_Overlord && u->isUnderAttack()))) { //Clear from scouting if stopped moving or overlord is under attack
-			if (u_type == UnitTypes::Zerg_Overlord) scouting.clearScout(u);
-			if (u_type == UnitTypes::Zerg_Zergling) scouting.clearScout(u);
+			if (u_type == UnitTypes::Zerg_Overlord) 
+				scouting.clearScout(u);
+			if (u_type == UnitTypes::Zerg_Zergling) 
+				scouting.clearScout(u);
+			
 		}
 
         //Combat Logic. Has some sophistication at this time. Makes retreat/attack decision.  Only retreat if your army is not up to snuff. Only combat units retreat. Only retreat if the enemy is near. Lings only attack ground. 

--- a/Source/CUNYAIModule.cpp
+++ b/Source/CUNYAIModule.cpp
@@ -683,7 +683,7 @@ void CUNYAIModule::onFrame()
 
 		// Scout Assignment Logic. Before Combat logic so scouts don't attack
 		if (scouting.needScout(u, t_game) && (u_type == UnitTypes::Zerg_Overlord || u_type == UnitTypes::Zerg_Zergling)) {
-			Position scout_spot = scouting.getScoutTargets(u, inventory, enemy_player_model.units_);
+			Position scout_spot = scouting.getScoutTargets(u, current_map_inventory, enemy_player_model.units_);
 
 			if (u_type == UnitTypes::Zerg_Zergling && !scouting._exists_zergling_scout) {
 				scouting.setScout(u);

--- a/Source/Map_Inventory.h
+++ b/Source/Map_Inventory.h
@@ -48,6 +48,7 @@ struct Map_Inventory {
     vector<Position> start_positions_;
     vector<TilePosition> expo_positions_;
     vector<TilePosition> expo_positions_complete_;
+	vector <TilePosition> enemy_buildings_;
     Position enemy_base_ground_;
     Position enemy_base_air_;
     Position home_base_;
@@ -192,6 +193,8 @@ struct Map_Inventory {
     // Updates map positions and removes all visible ones;
     void Map_Inventory::updateStartPositions(const Unit_Inventory &ei);
 
+	// Gets the mean location of all enemy buildings
+	Position Map_Inventory::getMeanEnemyBuildingLocation(Unit_Inventory &ei) const;
 
     // Calls most of the map update functions when needed at a reduced and somewhat reasonable rate.
     void updateBasePositions(Unit_Inventory & ui, Unit_Inventory & ei, const Resource_Inventory & ri, const Unit_Inventory & ni, const Unit_Inventory &di);

--- a/Source/PlayerModelManager.h
+++ b/Source/PlayerModelManager.h
@@ -4,6 +4,7 @@
 #include "Research_Inventory.h"
 #include "Unit_Inventory.h"
 #include "CobbDouglas.h"
+#include "ScoutingManager.h"
 
 using namespace std;
 using namespace BWAPI;
@@ -25,6 +26,7 @@ struct Player_Model {
     bool u_relatively_weak_against_air_; 
     bool e_relatively_weak_against_air_;
 
+	void gameStartConditions();
     void updateOtherOnFrame(const Player &other_player);
     void updateSelfOnFrame(const Player_Model &target_player);
     void evaluateWorkerCount();

--- a/Source/ScoutingManager.h
+++ b/Source/ScoutingManager.h
@@ -23,6 +23,8 @@ struct ScoutingManager {
 
 	vector<Position> scout_start_positions_;
 	vector<Position> scout_expo_positions_;
+
+	vector<int> scout_expo_distances_;
 	
 	// Initalizer
 	ScoutingManager();

--- a/Source/ScoutingManager.h
+++ b/Source/ScoutingManager.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <BWAPI.h>
+#include "CUNYAIModule.h"
+
+// Work in progress -- Missing some major features / bug fixes
+struct ScoutingManager {
+	int _last_overlord_scout_sent;
+	int _last_zergling_scout_sent;
+	bool _let_overlords_scout;
+	bool _exists_overlord_scout;
+	bool _exists_zergling_scout;
+	Unit _overlord_scout;
+	Unit _zergling_scout;
+	Unit _last_overlord_scout;
+	Unit _last_zergling_scout;
+	
+	// Initalizer
+	ScoutingManager();
+
+	// Checks if unit is our scouting unit
+	Position getScoutTargets(const Unit &unit, Map_Inventory &inv, Unit_Inventory &ei);
+	void updateScouts();
+	bool needScout(const Unit &unit, const int &t_game);
+	void setScout(const Unit &unit);
+	void clearScout(const Unit &unit);
+	bool isScoutingUnit(const Unit &unit);
+	void sendScout(const Unit &unit, const Position &scout_spot);
+};

--- a/Source/ScoutingManager.h
+++ b/Source/ScoutingManager.h
@@ -8,7 +8,7 @@ struct ScoutingManager {
 	int last_zergling_scout_sent_;
 
 	bool initial_scouts_;
-	bool let_overlords_scout_;  // Currently only false against Terran
+	bool let_overlords_scout_;  // False against Terran of if enemy can attack overlords
 	bool exists_overlord_scout_;
 	bool exists_zergling_scout_;
 	bool exists_expo_zergling_scout_;

--- a/Source/ScoutingManager.h
+++ b/Source/ScoutingManager.h
@@ -3,17 +3,26 @@
 #include <BWAPI.h>
 #include "CUNYAIModule.h"
 
-// Work in progress -- Missing some major features / bug fixes
 struct ScoutingManager {
 	int last_overlord_scout_sent_;
 	int last_zergling_scout_sent_;
-	bool let_overlords_scout_;
+
+	bool initial_scouts_;
+	bool let_overlords_scout_;  // Currently only false against Terran
 	bool exists_overlord_scout_;
 	bool exists_zergling_scout_;
+	bool exists_expo_zergling_scout_;
+	bool found_enemy_base_;
+
 	Unit overlord_scout_;
 	Unit zergling_scout_;
+	Unit expo_zergling_scout_;
 	Unit last_overlord_scout_;
 	Unit last_zergling_scout_;
+	Unit last_expo_scout_;
+
+	vector<Position> scout_start_positions_;
+	vector<Position> scout_expo_positions_;
 	
 	// Initalizer
 	ScoutingManager();
@@ -21,9 +30,9 @@ struct ScoutingManager {
 	// Checks if unit is our scouting unit
 	Position getScoutTargets(const Unit &unit, Map_Inventory &inv, Unit_Inventory &ei);
 	void updateScouts();
-	bool needScout(const Unit &unit, const int &t_game);
-	void setScout(const Unit &unit);
+	bool needScout(const Unit &unit, const int &t_game) const;
+	void setScout(const Unit &unit, const int &ling_type=0);
 	void clearScout(const Unit &unit);
-	bool isScoutingUnit(const Unit &unit);
-	void sendScout(const Unit &unit, const Position &scout_spot);
+	bool isScoutingUnit(const Unit &unit) const;
+	void sendScout(const Unit &unit, const Position &scout_spot) const;
 };

--- a/Source/ScoutingManager.h
+++ b/Source/ScoutingManager.h
@@ -5,15 +5,15 @@
 
 // Work in progress -- Missing some major features / bug fixes
 struct ScoutingManager {
-	int _last_overlord_scout_sent;
-	int _last_zergling_scout_sent;
-	bool _let_overlords_scout;
-	bool _exists_overlord_scout;
-	bool _exists_zergling_scout;
-	Unit _overlord_scout;
-	Unit _zergling_scout;
-	Unit _last_overlord_scout;
-	Unit _last_zergling_scout;
+	int last_overlord_scout_sent_;
+	int last_zergling_scout_sent_;
+	bool let_overlords_scout_;
+	bool exists_overlord_scout_;
+	bool exists_zergling_scout_;
+	Unit overlord_scout_;
+	Unit zergling_scout_;
+	Unit last_overlord_scout_;
+	Unit last_zergling_scout_;
 	
 	// Initalizer
 	ScoutingManager();


### PR DESCRIPTION
Functional Scouting Manager
-- Supports three scouts: A suicidal zergling every 30 seconds, A expo zergling scout at all times, and an overlord scout every 60 seconds.
-- Overlord scouts are currently permanently disabled against Terran and become permanently disabled when the enemy has units that can kill them.
-- Suicidal zergling scout runs to the closest enemy building near the MeanEnemyBuilding Position.
-- Expo zergling scout is always checking bases near enemy for potential bases.
-- Scouting units don't engage in combat and run to their assigned scouting position.
-- Scouting is disabled when we require all our combat units (we are either under threat of losing the game or our army greatly outnumbers the enemy and victory should be imminent).