### PR TITLE
BuildFAP (#130)

### DIFF
--- a/AssemblyManager.cpp
+++ b/AssemblyManager.cpp
@@ -40,8 +40,8 @@ bool CUNYAIModule::Check_N_Build(const UnitType &building, const Unit &unit, con
                 return true;
             }
             else if (buildorder.checkBuilding_Desired(building)) {
-                CUNYAIModule::DiagnosticText("I can't put a %s at (%d, %d) for you. Skip it and go on?...", building.c_str(), buildPosition.x, buildPosition.y);
-                buildorder.updateRemainingBuildOrder(building); // skips the building.
+                CUNYAIModule::DiagnosticText("I can't put a %s at (%d, %d) for you. Freeze here please!...", building.c_str(), buildPosition.x, buildPosition.y);
+                //buildorder.updateRemainingBuildOrder(building); // skips the building.
             }
         }
         else if (unit_can_build_intended_target && building == UnitTypes::Zerg_Creep_Colony) { // creep colony loop specifically.
@@ -227,13 +227,10 @@ bool CUNYAIModule::Check_N_Research(const TechType &tech, const Unit &unit, cons
 //Checks if a unit can be built from a larva, and passes additional boolean criteria.  If all critera are passed, then it performs the upgrade. Requires extra critera.  Updates friendly_player_model.units_.
 bool CUNYAIModule::Check_N_Grow(const UnitType &unittype, const Unit &larva, const bool &extra_critera)
 {
-    if (mustCreate(larva, unittype, extra_critera))
+
+    if (checkDesirable(larva, unittype, extra_critera))
     {
         if (larva->morph(unittype)) {
-            buildorder.updateRemainingBuildOrder(unittype); // Shouldn't be a problem if unit isn't in buildorder.
-            if (unittype.isTwoUnitsInOneEgg()) {
-                buildorder.updateRemainingBuildOrder(unittype); // Shouldn't be a problem if unit isn't in buildorder.
-            }
             Stored_Unit& morphing_unit = friendly_player_model.units_.unit_inventory_.find(larva)->second;
             morphing_unit.updateStoredUnit(larva);
             return true;
@@ -290,10 +287,12 @@ bool CUNYAIModule::Reactive_Build(const Unit &larva, const Map_Inventory &inv, U
     //    Stored_Unit(UnitTypes::Zerg_Hive).stock_value_ - Stock_Buildings(UnitTypes::Zerg_Hive, ui) +
     //    TechTypes::Lurker_Aspect.mineralPrice() + 1.25 * TechTypes::Lurker_Aspect.gasPrice() - Stock_Tech(TechTypes::Lurker_Aspect);
 
+
     //int remaining_cost_to_get_mutas = Stored_Unit(UnitTypes::Zerg_Spawning_Pool).stock_value_ - Stock_Units(UnitTypes::Zerg_Spawning_Pool, ui) +
     //    Stored_Unit(UnitTypes::Zerg_Spire).stock_value_ - Stock_Buildings(UnitTypes::Zerg_Spire, ui) +
     //    Stored_Unit(UnitTypes::Zerg_Lair).stock_value_ - Stock_Buildings(UnitTypes::Zerg_Lair, ui) +
     //    Stored_Unit(UnitTypes::Zerg_Hive).stock_value_ - Stock_Buildings(UnitTypes::Zerg_Hive, ui);
+
 
     //if (Inventory::getMapValue(inv.enemy_base_ground_, inv.map_out_from_home_) == 0) { e_relatively_weak_against_air = true; u_relatively_weak_against_air = true; } // If this is an island situation...Untested.
 
@@ -435,9 +434,10 @@ bool CUNYAIModule::Reactive_Build(const Unit &larva, const Map_Inventory &inv, U
 bool CUNYAIModule::Building_Begin(const Unit &drone, const Map_Inventory &inv, const Unit_Inventory &e_inv) {
     // will send it to do the LAST thing on this list that it can build.
     bool buildings_started = false;
-    bool expansion_vital = current_map_inventory.min_fields_ < current_map_inventory.hatches_ * 5 || inv.workers_distance_mining_ > 0.0625 * inv.min_workers_; // 1/16 workers LD mining is too much.
-    bool expansion_meaningful = (Count_Units(UnitTypes::Zerg_Drone) < 85 && (current_map_inventory.min_workers_ > current_map_inventory.min_fields_ * 2 || current_map_inventory.gas_workers_ > 2 * Count_Units(UnitTypes::Zerg_Extractor))) || expansion_vital;
+    bool any_macro_problems = current_map_inventory.min_workers_ > current_map_inventory.min_fields_ * 1.75 || current_map_inventory.gas_workers_ > 2 * Count_Units(UnitTypes::Zerg_Extractor) || current_map_inventory.min_fields_ < current_map_inventory.hatches_ * 5 || current_map_inventory.workers_distance_mining_ > 0.0625 * current_map_inventory.min_workers_; // 1/16 workers LD mining is too much.
+    bool expansion_meaningful = Count_Units(UnitTypes::Zerg_Drone) < 85 && (any_macro_problems);
     bool larva_starved = Count_Units(UnitTypes::Zerg_Larva) <= Count_Units(UnitTypes::Zerg_Hatchery);
+    bool the_only_macro_hatch_case = (larva_starved && !expansion_meaningful && !econ_starved);
     bool upgrade_bool = (tech_starved || (Count_Units(UnitTypes::Zerg_Larva) == 0 && !army_starved));
     bool lurker_tech_progressed = Broodwar->self()->hasResearched(TechTypes::Lurker_Aspect) + Broodwar->self()->isResearching(TechTypes::Lurker_Aspect);
     bool one_tech_per_base = Count_Units(UnitTypes::Zerg_Hydralisk_Den) /*+ Broodwar->self()->hasResearched(TechTypes::Lurker_Aspect) + Broodwar->self()->isResearching(TechTypes::Lurker_Aspect)*/ + Count_Units(UnitTypes::Zerg_Spire) + Count_Units(UnitTypes::Zerg_Ultralisk_Cavern) < Count_Units(UnitTypes::Zerg_Hatchery) - Count_Units_In_Progress(UnitTypes::Zerg_Hatchery);
@@ -445,14 +445,14 @@ bool CUNYAIModule::Building_Begin(const Unit &drone, const Map_Inventory &inv, c
         (Count_Units(UnitTypes::Zerg_Evolution_Chamber) - Broodwar->self()->incompleteUnitCount(UnitTypes::Zerg_Evolution_Chamber) > 0); // There is a building complete that will allow either creep colony upgrade.
     bool enemy_mostly_ground = e_inv.stock_ground_units_ > e_inv.stock_fighting_total_ * 0.75;
     bool enemy_lacks_AA = e_inv.stock_shoots_up_ < 0.25 * e_inv.stock_fighting_total_;
-    bool nearby_enemy = checkOccupiedArea(enemy_player_model.units_,drone->getPosition(), inv.my_portion_of_the_map_);
+    bool nearby_enemy = checkOccupiedArea(enemy_player_model.units_,drone->getPosition(), current_map_inventory.my_portion_of_the_map_);
 
     Unit_Inventory e_loc;
     Unit_Inventory u_loc;
 
     if (nearby_enemy) {
-        e_loc = getUnitInventoryInRadius(e_inv, drone->getPosition(), inv.my_portion_of_the_map_);
-        u_loc = getUnitInventoryInRadius(friendly_player_model.units_, drone->getPosition(), inv.my_portion_of_the_map_);
+        e_loc = getUnitInventoryInRadius(e_inv, drone->getPosition(), current_map_inventory.my_portion_of_the_map_);
+        u_loc = getUnitInventoryInRadius(friendly_player_model.units_, drone->getPosition(), current_map_inventory.my_portion_of_the_map_);
     }
 
     // Trust the build order. If there is a build order and it wants a building, build it!
@@ -463,12 +463,14 @@ bool CUNYAIModule::Building_Begin(const Unit &drone, const Map_Inventory &inv, c
     }
 
     //Macro-related Buildings.
-    if( !buildings_started ) buildings_started = Expo(drone, (!army_starved || enemy_player_model.units_.moving_average_fap_stock_<= friendly_player_model.units_.moving_average_fap_stock_ || expansion_vital) && (expansion_meaningful || larva_starved || econ_starved), current_map_inventory);
+    if( !buildings_started ) buildings_started = Expo(drone, (expansion_meaningful || larva_starved || econ_starved) && !the_only_macro_hatch_case, current_map_inventory);
     //buildings_started = expansion_meaningful; // stop if you need an expo!
-    if( !buildings_started ) buildings_started = Check_N_Build(UnitTypes::Zerg_Hatchery, drone, larva_starved && inv.min_workers_ + inv.gas_workers_ > inv.hatches_ * 5); // only macrohatch if you are short on larvae and can afford to spend.
+
+    if( !buildings_started ) buildings_started = Check_N_Build(UnitTypes::Zerg_Hatchery, drone, the_only_macro_hatch_case); // only macrohatch if you are short on larvae and can afford to spend.
+
     
     if( !buildings_started) buildings_started = Check_N_Build(UnitTypes::Zerg_Extractor, drone,
-        (inv.gas_workers_ >= 2 * (Count_Units(UnitTypes::Zerg_Extractor) - Broodwar->self()->incompleteUnitCount(UnitTypes::Zerg_Extractor)) && gas_starved) &&
+        (current_map_inventory.gas_workers_ >= 2 * (Count_Units(UnitTypes::Zerg_Extractor) - Broodwar->self()->incompleteUnitCount(UnitTypes::Zerg_Extractor)) && gas_starved) &&
         Broodwar->self()->incompleteUnitCount(UnitTypes::Zerg_Extractor) == 0);  // wait till you have a spawning pool to start gathering gas. If your gas is full (or nearly full) get another extractor.  Note that gas_workers count may be off. Sometimes units are in the gas geyser.
 
     //Combat Buildings
@@ -476,8 +478,9 @@ bool CUNYAIModule::Building_Begin(const Unit &drone, const Map_Inventory &inv, c
         Count_Units(UnitTypes::Zerg_Creep_Colony) * 50 + 50 <= my_reservation.getExcessMineral() && // Only build a creep colony if we can afford to upgrade the ones we have.
         can_upgrade_colonies &&
         (nearby_enemy || larva_starved || supply_starved) && // Only throw down a sunken if you have no larva floating around, or need the supply.
-        inv.hatches_ > 1 &&
-        Count_Units(UnitTypes::Zerg_Sunken_Colony) + Count_Units(UnitTypes::Zerg_Spore_Colony) < max( (inv.hatches_ * (inv.hatches_ + 1)) / 2, 6) ); // and you're not flooded with sunkens. Spores could be ok if you need AA.  as long as you have sum(hatches+hatches-1+hatches-2...)>sunkens.
+        current_map_inventory.hatches_ > 1 &&
+        Count_Units(UnitTypes::Zerg_Sunken_Colony) + Count_Units(UnitTypes::Zerg_Spore_Colony) < max( (current_map_inventory.hatches_ * (current_map_inventory.hatches_ + 1)) / 2, 6) ); // and you're not flooded with sunkens. Spores could be ok if you need AA.  as long as you have sum(hatches+hatches-1+hatches-2...)>sunkens.
+
 
    
     //First Building needed!
@@ -490,33 +493,33 @@ bool CUNYAIModule::Building_Begin(const Unit &drone, const Map_Inventory &inv, c
             Count_Units(UnitTypes::Zerg_Evolution_Chamber) == 0 &&
             Count_Units(UnitTypes::Zerg_Lair) - Broodwar->self()->incompleteUnitCount(UnitTypes::Zerg_Lair) > 0 &&
             Count_Units(UnitTypes::Zerg_Spawning_Pool) > 0 &&
-            inv.hatches_ > 1);
+            current_map_inventory.hatches_ > 1);
         if (!buildings_started) buildings_started = Check_N_Build(UnitTypes::Zerg_Hydralisk_Den, drone, upgrade_bool && one_tech_per_base &&
             Count_Units(UnitTypes::Zerg_Spawning_Pool) > 0 &&
             Count_Units(UnitTypes::Zerg_Hydralisk_Den) == 0 &&
-            inv.hatches_ > 1);
+            current_map_inventory.hatches_ > 1);
         if (!buildings_started) buildings_started = Check_N_Build(UnitTypes::Zerg_Spire, drone, upgrade_bool && one_tech_per_base &&
             Count_Units(UnitTypes::Zerg_Spire) == 0 &&
             Count_Units(UnitTypes::Zerg_Lair) > 0 &&
-            inv.hatches_ > 1);
+            current_map_inventory.hatches_ > 1);
         if (!buildings_started) buildings_started = Check_N_Build(UnitTypes::Zerg_Queens_Nest, drone, upgrade_bool &&
             Count_Units(UnitTypes::Zerg_Queens_Nest) == 0 &&
             Count_Units(UnitTypes::Zerg_Lair) > 0 &&
             Count_Units(UnitTypes::Zerg_Spire) > 0 &&
-            inv.hatches_ > 3); // no less than 3 bases for hive please. // Spires are expensive and it will probably skip them unless it is floating a lot of gas.
+            current_map_inventory.hatches_ > 3); // no less than 3 bases for hive please. // Spires are expensive and it will probably skip them unless it is floating a lot of gas.
     }
     else if (!friendly_player_model.e_relatively_weak_against_air_) {
 
         if (!buildings_started) buildings_started = Check_N_Build(UnitTypes::Zerg_Hydralisk_Den, drone, upgrade_bool && one_tech_per_base &&
             Count_Units(UnitTypes::Zerg_Spawning_Pool) > 0 &&
             Count_Units(UnitTypes::Zerg_Hydralisk_Den) == 0 &&
-            inv.hatches_ > 1);
+            current_map_inventory.hatches_ > 1);
 
         if (!buildings_started) buildings_started = Check_N_Build(UnitTypes::Zerg_Evolution_Chamber, drone, upgrade_bool &&
             Count_Units(UnitTypes::Zerg_Evolution_Chamber) == 0 &&
             Count_Units(UnitTypes::Zerg_Lair) - Broodwar->self()->incompleteUnitCount(UnitTypes::Zerg_Lair) > 0 &&
             Count_Units(UnitTypes::Zerg_Spawning_Pool) > 0 &&
-            inv.hatches_ > 1);
+            current_map_inventory.hatches_ > 1);
 
         // >2 bases
         if (!buildings_started) buildings_started = Check_N_Build(UnitTypes::Zerg_Evolution_Chamber, drone, upgrade_bool &&
@@ -525,31 +528,31 @@ bool CUNYAIModule::Building_Begin(const Unit &drone, const Map_Inventory &inv, c
             Count_Units(UnitTypes::Zerg_Lair) - Broodwar->self()->incompleteUnitCount(UnitTypes::Zerg_Lair) > 0 &&
             Count_Units_Doing(UnitTypes::Zerg_Evolution_Chamber, UnitCommandTypes::Morph, Broodwar->self()->getUnits()) == 0 && //costly, slow.
             Count_Units(UnitTypes::Zerg_Spawning_Pool) > 0 &&
-            inv.hatches_ > 2);
+            current_map_inventory.hatches_ > 2);
 
         // >3 bases
         if (!buildings_started) buildings_started = Check_N_Build(UnitTypes::Zerg_Queens_Nest, drone, upgrade_bool &&
             Count_Units(UnitTypes::Zerg_Queens_Nest) == 0 &&
             Count_Units(UnitTypes::Zerg_Lair) > 0 &&
             Count_Units(UnitTypes::Zerg_Spire) > 0 &&
-            inv.hatches_ > 3); // no less than 3 bases for hive please. // Spires are expensive and it will probably skip them unless it is floating a lot of gas.
+            current_map_inventory.hatches_ > 3); // no less than 3 bases for hive please. // Spires are expensive and it will probably skip them unless it is floating a lot of gas.
 
         if (!buildings_started) buildings_started = Check_N_Build(UnitTypes::Zerg_Ultralisk_Cavern, drone, upgrade_bool && one_tech_per_base &&
             Count_Units(UnitTypes::Zerg_Ultralisk_Cavern) == 0 &&
             Count_Units(UnitTypes::Zerg_Hive) >= 0 &&
-            inv.hatches_ > 3);
+            current_map_inventory.hatches_ > 3);
     }
     else if (friendly_player_model.e_relatively_weak_against_air_) {
         if (!buildings_started) buildings_started = Check_N_Build(UnitTypes::Zerg_Spire, drone, upgrade_bool && one_tech_per_base &&
             Count_Units(UnitTypes::Zerg_Spire) == 0 &&
             Count_Units(UnitTypes::Zerg_Lair) > 0 &&
-            inv.hatches_ > 1);
+            current_map_inventory.hatches_ > 1);
         // >3 bases
         if (!buildings_started) buildings_started = Check_N_Build(UnitTypes::Zerg_Queens_Nest, drone, upgrade_bool &&
             Count_Units(UnitTypes::Zerg_Queens_Nest) == 0 &&
             Count_Units(UnitTypes::Zerg_Lair) > 0 &&
             Count_Units(UnitTypes::Zerg_Spire) > 0 &&
-            inv.hatches_ > 3); // no less than 3 bases for hive please. // Spires are expensive and it will probably skip them unless it is floating a lot of gas.
+            current_map_inventory.hatches_ > 3); // no less than 3 bases for hive please. // Spires are expensive and it will probably skip them unless it is floating a lot of gas.
     }
 
         Stored_Unit& morphing_unit = friendly_player_model.units_.unit_inventory_.find(drone)->second;
@@ -563,13 +566,15 @@ TilePosition CUNYAIModule::getBuildablePosition( const TilePosition target_pos, 
 
     TilePosition canidate_return_position = TilePosition (0,0);
     int widest_dim_in_minitiles = 4 * max(build_type.tileHeight(), build_type.tileWidth());
+    int width = Broodwar->mapWidth();
+    int height = Broodwar->mapHeight();
     for (int x = -tile_grid_size; x <= tile_grid_size; ++x) {
         for (int y = -tile_grid_size; y <= tile_grid_size; ++y) {
             int centralize_x = target_pos.x + x;
             int centralize_y = target_pos.y + y;
             if (!(x == 0 && y == 0) &&
-                centralize_x < Broodwar->mapWidth() &&
-                centralize_y < Broodwar->mapHeight() &&
+                centralize_x < width &&
+                centralize_y < height &&
                 centralize_x > 0 &&
                 centralize_y > 0 &&
                 Broodwar->canBuildHere(TilePosition(centralize_x, centralize_y), build_type) &&
@@ -621,19 +626,23 @@ bool CUNYAIModule::Reactive_BuildFAP(const Unit &morph_canidate, const Map_Inven
     if (is_building) return is_building; // combat simulations are very costly.
 
     //Let us simulate some combat.
-    map<UnitType, int> all_combat_types = { { UnitTypes::Zerg_Ultralisk, INT_MIN } ,{ UnitTypes::Zerg_Mutalisk, INT_MIN },{ UnitTypes::Zerg_Scourge, INT_MIN },{ UnitTypes::Zerg_Hydralisk, INT_MIN },{ UnitTypes::Zerg_Zergling , INT_MIN },{ UnitTypes::Zerg_Lurker, INT_MIN } ,{ UnitTypes::Zerg_Guardian, INT_MIN } ,{ UnitTypes::Zerg_Devourer, INT_MIN } };
-    is_building = CUNYAIModule::buildOptimalUnit(morph_canidate, all_combat_types);
+    is_building = CUNYAIModule::buildOptimalUnit(morph_canidate, friendly_player_model.combat_unit_cartridge_);
+
 
     return is_building;
 
 }
 
 bool CUNYAIModule::buildStaticDefence(const Unit &morph_canidate) {
-    bool can_make_spore = mustCreate(morph_canidate, UnitTypes::Zerg_Spore_Colony, true);
-    bool can_make_sunken = mustCreate(morph_canidate, UnitTypes::Zerg_Sunken_Colony, true);
 
-    if (friendly_player_model.u_relatively_weak_against_air_ && can_make_spore) return morph_canidate->morph(UnitTypes::Zerg_Spore_Colony);
-    else if (!friendly_player_model.u_relatively_weak_against_air_ && can_make_sunken) return morph_canidate->morph(UnitTypes::Zerg_Sunken_Colony);
+    if (checkFeasibleRequirement(morph_canidate, UnitTypes::Zerg_Spore_Colony, true)) return morph_canidate->morph(UnitTypes::Zerg_Spore_Colony);
+    else if (checkFeasibleRequirement(morph_canidate, UnitTypes::Zerg_Sunken_Colony, true)) return morph_canidate->morph(UnitTypes::Zerg_Sunken_Colony);
+
+    bool must_make_spore = checkDesirable(morph_canidate, UnitTypes::Zerg_Spore_Colony, true);
+    bool must_make_sunken = checkDesirable(morph_canidate, UnitTypes::Zerg_Sunken_Colony, true);
+
+    if (friendly_player_model.u_relatively_weak_against_air_ && must_make_spore) return morph_canidate->morph(UnitTypes::Zerg_Spore_Colony);
+    else if (!friendly_player_model.u_relatively_weak_against_air_ && must_make_sunken) return morph_canidate->morph(UnitTypes::Zerg_Sunken_Colony);
 
     return false;
 }
@@ -647,10 +656,11 @@ bool CUNYAIModule::buildOptimalUnit(const Unit &morph_canidate, map<UnitType, in
     // drop all units types I cannot assemble at this time.
     auto pt_type = combat_types.begin();
     while (pt_type != combat_types.end()) {
-        bool can_make_or_already_is = morph_canidate->getType() == pt_type->first || mustCreate( morph_canidate, pt_type->first, true);
+        bool can_make_or_already_is = morph_canidate->getType() == pt_type->first || checkDesirable( morph_canidate, pt_type->first, true);
         bool is_larva = morph_canidate->getType() == UnitTypes::Zerg_Larva;
-        bool can_morph_into_prerequisite_hydra = mustCreate(morph_canidate, UnitTypes::Zerg_Lurker, true);
-        bool can_morph_into_prerequisite_muta = mustCreate(morph_canidate, UnitTypes::Zerg_Guardian, true); // or devourer
+        bool can_morph_into_prerequisite_hydra = checkDesirable(morph_canidate, UnitTypes::Zerg_Lurker, true) && pt_type->first == UnitTypes::Zerg_Lurker;
+        bool can_morph_into_prerequisite_muta = checkDesirable(morph_canidate, UnitTypes::Zerg_Guardian, true) && (pt_type->first == UnitTypes::Zerg_Guardian || pt_type->first == UnitTypes::Zerg_Devourer); 
+
 
         if (can_make_or_already_is || (is_larva && can_morph_into_prerequisite_hydra) || (is_larva && can_morph_into_prerequisite_muta)) {
             CUNYAIModule::DiagnosticText("Considering morphing a %s", pt_type->first.c_str());
@@ -714,9 +724,15 @@ UnitType CUNYAIModule::returnOptimalUnit(map<UnitType, int> &combat_types, const
 
 }
 
-bool CUNYAIModule::mustCreate(const Unit &unit, const UnitType &ut, const bool &extra_criteria) {
+
+bool CUNYAIModule::checkDesirable(const Unit &unit, const UnitType &ut, const bool &extra_criteria) {
     return Broodwar->canMake(ut, unit) && my_reservation.checkAffordablePurchase(ut) && (buildorder.checkBuilding_Desired(ut) || (extra_criteria && buildorder.isEmptyBuildOrder()));
 }
+
+bool CUNYAIModule::checkFeasibleRequirement(const Unit &unit, const UnitType &ut, const bool &extra_criteria) {
+    return Broodwar->canMake(ut, unit) && my_reservation.checkAffordablePurchase(ut) && buildorder.checkBuilding_Desired(ut);
+}
+
 
 void Building_Gene::updateRemainingBuildOrder(const Unit &u) {
     if (!building_gene_.empty()) {
@@ -805,10 +821,12 @@ void Building_Gene::getInitialBuildOrder(string s) {
     Build_Order_Object drone = Build_Order_Object(UnitTypes::Zerg_Drone);
     Build_Order_Object ovi = Build_Order_Object(UnitTypes::Zerg_Overlord);
     Build_Order_Object pool = Build_Order_Object(UnitTypes::Zerg_Spawning_Pool);
+    Build_Order_Object evo = Build_Order_Object(UnitTypes::Zerg_Evolution_Chamber);
     Build_Order_Object speed = Build_Order_Object(UpgradeTypes::Metabolic_Boost);
     Build_Order_Object ling = Build_Order_Object(UnitTypes::Zerg_Zergling);
     Build_Order_Object creep = Build_Order_Object(UnitTypes::Zerg_Creep_Colony);
     Build_Order_Object sunken = Build_Order_Object(UnitTypes::Zerg_Sunken_Colony);
+    Build_Order_Object spore = Build_Order_Object(UnitTypes::Zerg_Spore_Colony);
     Build_Order_Object lair = Build_Order_Object(UnitTypes::Zerg_Lair);
     Build_Order_Object spire = Build_Order_Object(UnitTypes::Zerg_Spire);
     Build_Order_Object muta = Build_Order_Object(UnitTypes::Zerg_Mutalisk);
@@ -838,6 +856,9 @@ void Building_Gene::getInitialBuildOrder(string s) {
         else if (build == "pool") {
             building_gene_.push_back(pool);
         }
+        else if (build == "evo") {
+            building_gene_.push_back(evo);
+        }
         else if (build == "speed") {
             building_gene_.push_back(speed);
         }
@@ -849,6 +870,9 @@ void Building_Gene::getInitialBuildOrder(string s) {
         }
         else if (build == "sunken") {
             building_gene_.push_back(sunken);
+        }
+        else if (build == "spore") {
+            building_gene_.push_back(spore);
         }
         else if (build == "lair") {
             building_gene_.push_back(lair);

--- a/CobbDouglas.cpp
+++ b/CobbDouglas.cpp
@@ -159,12 +159,22 @@ void CobbDouglas::printModelParameters() { // we have poorly named parameters, a
 
 bool CobbDouglas::evalArmyPossible()
 {
-    double K_over_L = static_cast<double>(CUNYAIModule::friendly_player_model.units_.stock_fighting_total_ + 1) / static_cast<double>(CUNYAIModule::friendly_player_model.units_.worker_count_ * Stored_Unit(UnitTypes::Zerg_Drone).stock_value_ + 1); // avoid NAN's
-    int units_on_field = CUNYAIModule::Count_Units(UnitTypes::Zerg_Spawning_Pool) - CUNYAIModule::Count_Units_In_Progress(UnitTypes::Zerg_Spawning_Pool)
-        + CUNYAIModule::Count_Units(UnitTypes::Zerg_Hydralisk_Den) - CUNYAIModule::Count_Units_In_Progress(UnitTypes::Zerg_Hydralisk_Den)
-        + CUNYAIModule::Count_Units(UnitTypes::Zerg_Spire) - CUNYAIModule::Count_Units_In_Progress(UnitTypes::Zerg_Spire)
-        + CUNYAIModule::Count_Units(UnitTypes::Zerg_Ultralisk_Cavern) - CUNYAIModule::Count_Units_In_Progress(UnitTypes::Zerg_Ultralisk_Cavern);
-   return (Broodwar->self()->supplyUsed() < 400 && K_over_L < 5 * alpha_army / alpha_tech) || units_on_field <= 0; // can't be army starved if you are maxed out (or close to it), Or if you have a wild K/L ratio. Or if you have nothing in production? These seem like freezers.
+
+    double K_over_L = static_cast<double>(army_stock + 1) / static_cast<double>(worker_stock + 1); // avoid NAN's
+
+    bool can_build_army = false;
+    auto combat_types = CUNYAIModule::friendly_player_model.combat_unit_cartridge_; // safe copy.
+
+    // drop all units types I cannot assemble at this time.
+    for(auto unit_selection:combat_types) {
+        if (Broodwar->canMake(unit_selection.first)) {
+            can_build_army = true;
+            break;
+        }
+    }
+
+   return (Broodwar->self()->supplyUsed() < 400 && K_over_L < 5 * alpha_army / alpha_tech) && can_build_army; // can't be army starved if you are maxed out (or close to it), Or if you have a wild K/L ratio. Or if you have nothing in production? These seem like freezers.
+
 }
 
 bool CobbDouglas::evalEconPossible()

--- a/GeneticHistoryManager.cpp
+++ b/GeneticHistoryManager.cpp
@@ -48,16 +48,18 @@ GeneticHistory::GeneticHistory(string file) {
 
     vector<string> build_order_list = {
         "drone drone drone drone drone overlord pool drone creep drone drone", // The blind sunken. For the bots that just won't take no for an answer.
-        "drone pool drone drone ling ling ling ling ling ling overlord ling ling ling ling ling ling ling ling ling ling ling ling ling ling ling ling", // 5pool with some commitment.
+        "drone pool drone drone ling ling ling overlord ling ling ling ling ling ling ling ling", // 5pool with some commitment.
         "drone drone drone drone drone overlord pool drone drone", // 9pool gasless
         "drone drone drone drone drone overlord pool drone extract drone drone", // 9pool
-        "drone drone drone drone drone overlord drone drone drone pool drone extract hatch ling ling ling ling ling ling speed", // 12-pool tenative.
+        "drone drone drone drone drone overlord drone drone drone pool drone extract hatch ling ling ling speed", // 12-pool tenative.
         "drone drone drone drone drone overlord drone drone drone hatch pool drone drone", // 12hatch-pool
-        "drone drone drone drone drone pool drone extract overlord drone ling ling ling ling ling ling lair drone overlord drone hydra_den hydra hydra hydra hydra ling ling ling ling ling ling ling ling lurker_tech", //1 h lurker, tenative.
-        "drone drone drone drone drone overlord drone drone drone hatch pool extract drone drone drone drone ling ling ling ling ling ling overlord lair drone drone drone speed drone drone drone overlord hydra_den drone drone drone drone lurker_tech creep drone creep drone sunken sunken drone drone drone drone drone overlord overlord hydra hydra hydra hydra ling ling ling ling lurker lurker lurker lurker ling ling ling ling", // 2h lurker
-        //"drone drone drone drone drone overlord drone drone drone hatch pool drone drone drone ling ling ling ling ling ling drone creep drone sunken creep drone sunken creep drone sunken creep drone sunken",  // 2 h turtle, tenative. Dies because the first hatch does not have creep by it when it is time to build.
-        "drone drone drone drone overlord drone drone drone hatch pool extract drone drone drone ling ling drone drone lair overlord drone drone speed drone drone drone drone drone drone drone drone spire drone extract drone creep drone creep drone sunken sunken overlord overlord muta muta muta muta muta muta muta muta muta muta muta muta", // 2h - Muta.  Requires another overlord?
-       "drone drone drone drone drone pool drone extract overlord drone ling ling ling ling ling ling hydra_den drone drone drone drone", //zerg_9pool to hydra one base.
+        "drone drone drone drone drone pool drone extract overlord drone ling ling ling lair drone overlord drone hydra_den hydra hydra hydra hydra ling ling ling ling lurker_tech", //1 h lurker, tenative.
+        "drone drone drone drone drone overlord drone drone drone hatch pool extract drone drone drone drone ling ling ling overlord lair drone drone drone speed drone drone drone overlord hydra_den drone drone drone drone lurker_tech creep drone creep drone sunken sunken drone drone drone drone drone overlord overlord hydra hydra hydra hydra ling ling lurker lurker lurker lurker ling ling", // 2h lurker
+        //"drone drone drone drone drone overlord drone drone drone hatch pool drone drone drone ling ling ling drone creep drone sunken creep drone sunken creep drone sunken creep drone sunken",  // 2 h turtle, tenative. Dies because the first hatch does not have creep by it when it is time to build.
+        //"drone drone drone drone drone overlord drone drone drone hatch pool drone drone drone drone drone drone drone creep drone sunken creep drone sunken creep drone sunken creep drone sunken evo drone creep spore", // Sunken Testing build. Superpassive.
+        //"drone drone drone drone drone overlord drone drone drone pool creep drone sunken creep drone sunken creep drone sunken creep drone sunken evo drone creep spore", // Sunken Testing build. Superpassive.
+        "drone drone drone drone overlord drone drone drone hatch pool extract drone drone drone ling drone drone lair overlord drone drone speed drone drone drone drone drone drone drone drone spire drone extract drone creep drone creep drone sunken sunken overlord overlord muta muta muta muta muta muta muta muta muta muta muta muta", // 2h - Muta.  Requires another overlord?
+       "drone drone drone drone drone pool drone extract overlord drone ling ling ling hydra_den drone drone drone drone", //zerg_9pool to hydra one base.
        "drone drone drone drone overlord drone drone drone hatch pool drone extract drone drone drone drone drone drone hydra_den drone overlord drone drone drone grooved_spines hydra hydra hydra hydra hydra hydra hydra overlord hydra hydra hydra hydra hydra hatch extract", //zerg_2hatchhydra -range added an overlord.
        "drone drone drone drone overlord drone drone drone hatch pool drone extract drone drone drone drone drone drone hydra_den drone overlord drone drone drone muscular_augments hydra hydra hydra hydra hydra hydra hydra overlord hydra hydra hydra hydra hydra hatch extract" //zerg_2hatchhydra - speed. added an overlord.
     };
@@ -229,6 +231,7 @@ GeneticHistory::GeneticHistory(string file) {
 
     double likelihood_w = race_or_player_w / static_cast<double>(win_count) * winning_map / static_cast<double>(win_count);
     double likelihood_l = race_or_player_l / static_cast<double>(lose_count) * losing_map / static_cast<double>(lose_count);
+
     double rand_value = dis(gen);
 
     prob_win_given_conditions = fmax((likelihood_w * win_count) / (likelihood_w * win_count + likelihood_l * lose_count), 0.0);
@@ -308,6 +311,7 @@ GeneticHistory::GeneticHistory(string file) {
         double crossover = dis(gen); //crossover, interior of parents. Big mutation at the end, though.
 
             //if we don't need diversity, combine our old wins together.
+
         if (dis(gen) < uniqueCount / static_cast<double>(build_order_list.size())) { // 
             //Parent 2 must match the build of the first one.
             build_order_out = build_order_win[parent_1];
@@ -432,6 +436,8 @@ GeneticHistory::GeneticHistory(string file) {
         a_econ_out_mutate_ = 0.488455;
         a_tech_out_mutate_ = 0.52895;
         r_out_mutate_ = 0.5097605;
-        build_order_ = "drone drone drone drone overlord drone drone drone hatch pool drone extract drone drone drone drone drone drone hydra_den drone overlord drone drone drone grooved_spines hydra hydra hydra hydra hydra hydra hydra overlord hydra hydra hydra hydra hydra hatch extract"; //zerg_2hatchhydra -range added an overlord.
+
+        build_order_ = "drone drone drone drone drone pool drone extract overlord drone ling ling ling hydra_den drone drone drone drone"; //zerg_9pool to hydra one base.
+
     }
 }

--- a/Map_Inventory.cpp
+++ b/Map_Inventory.cpp
@@ -263,7 +263,7 @@ void Map_Inventory::updateBuildablePos()
 
 void Map_Inventory::updateUnwalkable() {
     int map_x = Broodwar->mapWidth() * 4;
-    int map_y = Broodwar->mapHeight() * 4; //tile positions are 32x32, walkable checks 8x8 minitiles. 
+    int map_y = Broodwar->mapHeight() * 4; //tile positions are 32x32, walkable checks 8x8 minitiles.
 
     unwalkable_barriers_.reserve(map_x);
     // first, define matrixes to recieve the walkable locations for every minitile.
@@ -275,20 +275,20 @@ void Map_Inventory::updateUnwalkable() {
         }
         unwalkable_barriers_.push_back( temp );
     }
-    
+
     unwalkable_barriers_with_buildings_ = unwalkable_barriers_; // preparing for the dependencies.
 }
 
 void Map_Inventory::updateSmoothPos() {
     int map_x = Broodwar->mapWidth() * 4;
-    int map_y = Broodwar->mapHeight() * 4; //tile positions are 32x32, walkable checks 8x8 minitiles. 
+    int map_y = Broodwar->mapHeight() * 4; //tile positions are 32x32, walkable checks 8x8 minitiles.
     int choke_score = 0;
     bool changed_a_value_last_cycle;
 
     // first, define matrixes to recieve the walkable locations for every minitile.
     smoothed_barriers_ = unwalkable_barriers_;
 
-    for (auto iter = 2; iter < 16; iter++) { // iteration 1 is already done by labling unwalkables. Smoothout any dangerous tiles. 
+    for (auto iter = 2; iter < 16; iter++) { // iteration 1 is already done by labling unwalkables. Smoothout any dangerous tiles.
         changed_a_value_last_cycle = false;
         for (int minitile_x = 1; minitile_x <= map_x; ++minitile_x) {
             for (int minitile_y = 1; minitile_y <= map_y; ++minitile_y) { // Check all possible walkable locations.
@@ -331,7 +331,7 @@ void Map_Inventory::updateSmoothPos() {
 
 
                     changed_a_value_last_cycle = opposing_tiles || changed_a_value_last_cycle;
-                    smoothed_barriers_[minitile_x][minitile_y] = opposing_tiles * ( iter + open_path * (99 - 2 * iter) ); 
+                    smoothed_barriers_[minitile_x][minitile_y] = opposing_tiles * ( iter + open_path * (99 - 2 * iter) );
                 }
             }
         }
@@ -343,12 +343,13 @@ void Map_Inventory::updateSmoothPos() {
 
 void Map_Inventory::updateMapVeins() {
     int map_x = Broodwar->mapWidth() * 4;
-    int map_y = Broodwar->mapHeight() * 4; //tile positions are 32x32, walkable checks 8x8 minitiles. 
+    int map_y = Broodwar->mapHeight() * 4; //tile positions are 32x32, walkable checks 8x8 minitiles.
     bool changed_a_value_last_cycle = false;
 
     // first, define matrixes to recieve the walkable locations for every minitile.
     map_veins_.clear();
     map_veins_ = unwalkable_barriers_with_buildings_;
+
 
     list<WalkPosition> needs_filling;
     for (int minitile_x = 0; minitile_x < map_x; ++minitile_x) {
@@ -363,7 +364,7 @@ void Map_Inventory::updateMapVeins() {
     vector<int> flattened_map_veins;
     for (int minitile_x = 0; minitile_x < map_x; ++minitile_x) {
         for (int minitile_y = 0; minitile_y < map_y; ++minitile_y) { // Check all possible walkable locations. Must cross over the WHOLE matrix. No sloppy bits.
-            flattened_map_veins.push_back(map_veins_[minitile_x][minitile_y]);
+            flattened_map_veins.push_back( map_veins_[minitile_x][minitile_y] );
         }
     }
 
@@ -402,10 +403,10 @@ void Map_Inventory::updateMapVeins() {
             else ++position_to_investigate;
             //if ( local_grid ) {
             //    std::swap(*position_to_investigate, needs_filling.back()); // note back  - last element vs end - iterator past last element!
-            //    needs_filling.pop_back(); //std::erase preserves order and vectors are contiguous. Erase is then an O(n^2) operator. 
+            //    needs_filling.pop_back(); //std::erase preserves order and vectors are contiguous. Erase is then an O(n^2) operator.
             //}
-            //else { 
-            //    ++position_to_investigate; 
+            //else {
+            //    ++position_to_investigate;
             //}
         }
 
@@ -734,7 +735,7 @@ int Map_Inventory::getRadialDistanceOutFromHome( const Position A ) const
 // This function causes several items to break. In particular, building locations will end up being inside the unwalkable area!
 void Map_Inventory::updateUnwalkableWithBuildings(const Unit_Inventory &ui, const Unit_Inventory &ei, const Resource_Inventory &ri, const Unit_Inventory &ni) {
     int map_x = Broodwar->mapWidth() * 4;
-    int map_y = Broodwar->mapHeight() * 4; //tile positions are 32x32, walkable checks 8x8 minitiles. 
+    int map_y = Broodwar->mapHeight() * 4; //tile positions are 32x32, walkable checks 8x8 minitiles.
 
     unwalkable_barriers_with_buildings_ = unwalkable_barriers_;
 
@@ -839,7 +840,7 @@ void Map_Inventory::updateUnwalkableWithBuildings(const Unit_Inventory &ui, cons
 //void Map_Inventory::updateLiveMapVeins(const Unit_Inventory &ui, const Unit_Inventory &ei, const Resource_Inventory &ri) { // in progress.
 //
 //    int map_x = Broodwar->mapWidth() * 4;
-//    int map_y = Broodwar->mapHeight() * 4; //tile positions are 32x32, walkable checks 8x8 minitiles. 
+//    int map_y = Broodwar->mapHeight() * 4; //tile positions are 32x32, walkable checks 8x8 minitiles.
 //    int test_bool = 0;
 //                                           // Predefine grid we will search over.
 //    bool local_grid[3][3]; // WAY BETTER!
@@ -916,7 +917,7 @@ void Map_Inventory::updateUnwalkableWithBuildings(const Unit_Inventory &ui, cons
 
 //void Map_Inventory::updateMapChokes() { // in progress. Idea : A choke is if the maximum variation of ground distances in a 5x5 tile square is LESS than some threshold. It is a plane if it is GREATER than some threshold.
 //    int map_x = Broodwar->mapWidth() * 4;
-//    int map_y = Broodwar->mapHeight() * 4; //tile positions are 32x32, walkable checks 8x8 minitiles. 
+//    int map_y = Broodwar->mapHeight() * 4; //tile positions are 32x32, walkable checks 8x8 minitiles.
 //    WalkPosition map_dim = WalkPosition(TilePosition({ Broodwar->mapWidth(), Broodwar->mapHeight() }));
 //    int current_region_number = 1;
 //    int count_of_adjacent_importent_points = 0;
@@ -1079,7 +1080,7 @@ void Map_Inventory::updateBaseLoc( const Resource_Inventory &ri ) {
             for ( auto possible_base_tile_y = min_pos_t.y - 8; possible_base_tile_y != min_pos_t.y + 8; ++possible_base_tile_y ) { // Check wide area of possible build locations around each mineral.
 
                 if ( possible_base_tile_x >= 0 && possible_base_tile_x <= map_x &&
-                    possible_base_tile_y >= 0 && possible_base_tile_y <= map_y ) { // must be in the map bounds 
+                    possible_base_tile_y >= 0 && possible_base_tile_y <= map_y ) { // must be in the map bounds
 
                     TilePosition prosepective_location_upper_left = { possible_base_tile_x , possible_base_tile_y }; // The build location is upper left tile of the building. T
                     TilePosition prosepective_location_upper_right = { possible_base_tile_x + UnitTypes::Zerg_Hatchery.tileWidth() , possible_base_tile_y };
@@ -1282,7 +1283,7 @@ void Map_Inventory::getExpoPositions() {
 
             int x = canidate_spot.x;
             int y = canidate_spot.y;
-            
+
             for (int i = -12; i <= 12; i++) {
                 for (int j = -12; j <= 12; j++) {
                     bool safety_check = TilePosition(x + i, y + j).isValid(); //valid tile position
@@ -1297,7 +1298,7 @@ void Map_Inventory::getExpoPositions() {
                 expo_positions_.push_back(canidate_spot);
             }
         }
-    
+
     }
 
 
@@ -1339,7 +1340,7 @@ void Map_Inventory::updateBasePositions(Unit_Inventory &ui, Unit_Inventory &ei, 
 
     // Need to update map objects for every building!
     bool unit_calculation_frame = Broodwar->getFrameCount() % Broodwar->getLatencyFrames() != 0;
-    int frames_this_cycle = Broodwar->getFrameCount() % (24 * 4); // technically more. 
+    int frames_this_cycle = Broodwar->getFrameCount() % (24 * 4); // technically more.
 
                                                                   // every frame this is incremented.
     frames_since_enemy_base_ground_++;
@@ -1350,7 +1351,7 @@ void Map_Inventory::updateBasePositions(Unit_Inventory &ui, Unit_Inventory &ei, 
     frames_since_unwalkable++;
 
     //every 10 sec check if we're sitting at our destination.
-    //if (Broodwar->isVisible(TilePosition(enemy_base_ground_)) && Broodwar->getFrameCount() % (24 * 5) == 0) { 
+    //if (Broodwar->isVisible(TilePosition(enemy_base_ground_)) && Broodwar->getFrameCount() % (24 * 5) == 0) {
     //    fram = true;
     //}
     if (unit_calculation_frame) return;
@@ -1363,20 +1364,20 @@ void Map_Inventory::updateBasePositions(Unit_Inventory &ui, Unit_Inventory &ei, 
         frames_since_unwalkable = 0;
         return;
     }
-    
+
     if (frames_since_map_veins > 24 * 30) { // impose a second wait here because we don't want to update this if we're discovering buildings rapidly.
 
         updateMapVeins();
         frames_since_map_veins = 0;
         return;
     }
-    
+
     if (frames_since_enemy_base_ground_ > 24 * 10) {
         checked_all_expo_positions_ = false;
 
-        Stored_Unit* center_building = CUNYAIModule::getClosestGroundStored(ei, ui.getMeanLocation(), *this); // If the mean location is over water, nothing will be updated. Current problem: Will not update if on 
+        Stored_Unit* center_building = CUNYAIModule::getClosestGroundStored(ei, ui.getMeanLocation(), *this); // If the mean location is over water, nothing will be updated. Current problem: Will not update if on
 
-        if (ei.getMeanBuildingLocation() != Positions::Origin && center_building && center_building->pos_ && center_building->pos_ != Positions::Origin) { // Sometimes buildings get invalid positions. Unclear why. Then we need to use a more traditioanl method. 
+        if (ei.getMeanBuildingLocation() != Positions::Origin && center_building && center_building->pos_ && center_building->pos_ != Positions::Origin) { // Sometimes buildings get invalid positions. Unclear why. Then we need to use a more traditioanl method.
             updateMapVeinsOut( center_building->pos_, enemy_base_ground_, map_out_from_enemy_ground_, false); // don't print this one, it could be anywhere and to print all of them would end up filling up our hard drive.
         }
         else if (!start_positions_.empty() && start_positions_[0] && start_positions_[0] !=  Positions::Origin && !cleared_all_start_positions_) { // maybe it's an starting base we havent' seen yet?
@@ -1406,12 +1407,12 @@ void Map_Inventory::updateBasePositions(Unit_Inventory &ui, Unit_Inventory &ei, 
         frames_since_enemy_base_ground_ = 0;
         return;
     }
-    
-    if (frames_since_enemy_base_air_ > 24 * 5) {
-    
-        Stored_Unit* center_flyer = CUNYAIModule::getClosestAirStored(ei, ui.getMeanAirLocation(), *this); // If the mean location is over water, nothing will be updated. Current problem: Will not update if on 
 
-        if (ei.getMeanBuildingLocation() !=  Positions::Origin && center_flyer && center_flyer->pos_) { // Sometimes buildings get invalid positions. Unclear why. Then we need to use a more traditioanl method. 
+    if (frames_since_enemy_base_air_ > 24 * 5) {
+
+        Stored_Unit* center_flyer = CUNYAIModule::getClosestAirStored(ei, ui.getMeanAirLocation(), *this); // If the mean location is over water, nothing will be updated. Current problem: Will not update if on
+
+        if (ei.getMeanBuildingLocation() !=  Positions::Origin && center_flyer && center_flyer->pos_) { // Sometimes buildings get invalid positions. Unclear why. Then we need to use a more traditioanl method.
             updateMapVeinsOut(center_flyer->pos_, enemy_base_air_, map_out_from_enemy_air_, false);
         }
         else {
@@ -1515,7 +1516,7 @@ void Map_Inventory::writeMap(const vector< vector<int> > &mapin, const WalkPosit
     std::ostringstream merged_holding_vector;
     // Convert all but the last element to avoid a trailing ","
     std::copy(holding_vector.begin(), holding_vector.end() - 1,
-        std::ostream_iterator< int>(merged_holding_vector, "\n"));
+        std::ostream_iterator<int>(merged_holding_vector, "\n"));
     // Now add the last element with no delimiter
     merged_holding_vector << holding_vector.back();
 

--- a/PlayerModelManager.cpp
+++ b/PlayerModelManager.cpp
@@ -80,6 +80,12 @@ void Player_Model::updateSelfOnFrame(const Player_Model & target_player)
     radial_distances_from_enemy_ground_ = Map_Inventory::getRadialDistances(units_, CUNYAIModule::current_map_inventory.map_out_from_enemy_ground_);
     closest_radial_distance_enemy_ground_ = *std::min_element(radial_distances_from_enemy_ground_.begin(), radial_distances_from_enemy_ground_.end());
 
+    //Set default cartridges:
+    combat_unit_cartridge_ = { { UnitTypes::Zerg_Ultralisk, INT_MIN } ,{ UnitTypes::Zerg_Mutalisk, INT_MIN },{ UnitTypes::Zerg_Scourge, INT_MIN },{ UnitTypes::Zerg_Hydralisk, INT_MIN },{ UnitTypes::Zerg_Zergling , INT_MIN },{ UnitTypes::Zerg_Lurker, INT_MIN } ,{ UnitTypes::Zerg_Guardian, INT_MIN } ,{ UnitTypes::Zerg_Devourer, INT_MIN } };
+    building_cartridge_ = { { UnitTypes::Zerg_Spawning_Pool, INT_MIN } ,{ UnitTypes::Zerg_Evolution_Chamber, INT_MIN },{ UnitTypes::Zerg_Hydralisk_Den, INT_MIN },{ UnitTypes::Zerg_Spire, INT_MIN },{ UnitTypes::Zerg_Queens_Nest , INT_MIN },{ UnitTypes::Zerg_Ultralisk_Cavern, INT_MIN } ,{ UnitTypes::Zerg_Greater_Spire, INT_MIN } ,{ UnitTypes::Zerg_Lair, INT_MIN },{ UnitTypes::Zerg_Hive, INT_MIN } };
+    upgrade_cartridge_ = { { UpgradeTypes::Zerg_Carapace, INT_MIN } ,{ UpgradeTypes::Zerg_Flyer_Carapace, INT_MIN },{ UpgradeTypes::Zerg_Melee_Attacks, INT_MIN },{ UpgradeTypes::Zerg_Missile_Attacks, INT_MIN },{ UpgradeTypes::Zerg_Flyer_Attacks, INT_MIN },{ UpgradeTypes::Antennae, INT_MIN },{ UpgradeTypes::Pneumatized_Carapace, INT_MIN },{ UpgradeTypes::Metabolic_Boost, INT_MIN },{ UpgradeTypes::Adrenal_Glands, INT_MIN },{ UpgradeTypes::Muscular_Augments, INT_MIN },{ UpgradeTypes::Grooved_Spines, INT_MIN },{ UpgradeTypes::Chitinous_Plating, INT_MIN },{ UpgradeTypes::Anabolic_Synthesis, INT_MIN } };
+    tech_cartridge_ = { { TechTypes::Lurker_Aspect, INT_MIN } };
+
 };
 
 

--- a/Source/CUNYAIModule.cpp
+++ b/Source/CUNYAIModule.cpp
@@ -382,8 +382,6 @@ void CUNYAIModule::onFrame()
     //Broodwar->sendText("The spore is believed to be %s", TESTfap.getState().first->empty() ? "DEAD" : "ALIVE");
     //Broodwar->sendText("The wraith is believed to be %s", TESTfap.getState().second->empty() ? "DEAD" : "ALIVE");
 
-
-
     // Display the game status indicators at the top of the screen    
     if constexpr(DRAWING_MODE) {
 
@@ -489,28 +487,28 @@ void CUNYAIModule::onFrame()
         }
 
 
-        //for ( vector<int>::size_type i = 0; i < inventory.map_veins_.size(); ++i ) {
-        //    for ( vector<int>::size_type j = 0; j < inventory.map_veins_[i].size(); ++j ) {
-        //        if ( inventory.map_veins_[i][j] > 175 ) {
-        //            if (isOnScreen( { static_cast<int>i * 8 + 4, static_cast<int>j * 8 + 4 }, inventory.screen_position_) ) {
-        //                //Broodwar->drawTextMap(  i * 8 + 4, j * 8 + 4, "%d", inventory.map_veins_[i][j] );
-        //                Broodwar->drawCircleMap( i * 8 + 4, j * 8 + 4, 1, Colors::Cyan );
-        //            }
-        //        }
-        //        else if (inventory.map_veins_[i][j] < 20 && inventory.map_veins_[i][j] > 1 ) { // should only highlight smoothed-out barriers.
-        //            if (isOnScreen({ static_cast<int>i * 8 + 4, static_cast<int>j * 8 + 4 }, inventory.screen_position_)) {
-        //                //Broodwar->drawTextMap(  i * 8 + 4, j * 8 + 4, "%d", inventory.map_veins_[i][j] );
-        //                Broodwar->drawCircleMap(i * 8 + 4, j * 8 + 4, 1, Colors::Purple);
-        //            }
-        //        }
-        //        else if ( inventory.map_veins_[i][j] == 1 ) { // should only highlight smoothed-out barriers.
-        //            if (isOnScreen( { static_cast<int>i * 8 + 4, static_cast<int>j * 8 + 4 }, inventory.screen_position_) ) {
-        //                //Broodwar->drawTextMap(  i * 8 + 4, j * 8 + 4, "%d", inventory.map_veins_[i][j] );
-        //                Broodwar->drawCircleMap( i * 8 + 4, j * 8 + 4, 1, Colors::Red );
-        //            }
-        //        }
-        //    }
-        //} // Pretty to look at!
+        for ( vector<int>::size_type i = 0; i < current_map_inventory.map_veins_.size(); ++i ) {
+            for ( vector<int>::size_type j = 0; j < current_map_inventory.map_veins_[i].size(); ++j ) {
+                if (current_map_inventory.map_veins_[i][j] > 175 ) {
+                    if (isOnScreen( { static_cast<int>(i) * 8 + 4, static_cast<int>(j) * 8 + 4 }, current_map_inventory.screen_position_) ) {
+                        //Broodwar->drawTextMap(  i * 8 + 4, j * 8 + 4, "%d", inventory.map_veins_[i][j] );
+                        Broodwar->drawCircleMap( i * 8 + 4, j * 8 + 4, 1, Colors::Cyan );
+                    }
+                }
+                else if (current_map_inventory.map_veins_[i][j] < 20 && current_map_inventory.map_veins_[i][j] > 1 ) { // should only highlight smoothed-out barriers.
+                    if (isOnScreen({ static_cast<int>(i) * 8 + 4, static_cast<int>(j) * 8 + 4 }, current_map_inventory.screen_position_)) {
+                        //Broodwar->drawTextMap(  i * 8 + 4, j * 8 + 4, "%d", inventory.map_veins_[i][j] );
+                        Broodwar->drawCircleMap(i * 8 + 4, j * 8 + 4, 1, Colors::Purple);
+                    }
+                }
+                else if (current_map_inventory.map_veins_[i][j] == 1 ) { // should only highlight smoothed-out barriers.
+                    if (isOnScreen( { static_cast<int>(i) * 8 + 4, static_cast<int>(j) * 8 + 4 }, current_map_inventory.screen_position_) ) {
+                        //Broodwar->drawTextMap(  i * 8 + 4, j * 8 + 4, "%d", inventory.map_veins_[i][j] );
+                        Broodwar->drawCircleMap( i * 8 + 4, j * 8 + 4, 1, Colors::Red );
+                    }
+                }
+            }
+        } // Pretty to look at!
 
 
         //for (vector<int>::size_type i = 0; i < inventory.map_out_from_home_.size(); ++i) {
@@ -608,7 +606,7 @@ void CUNYAIModule::onFrame()
             {
                 // Build appropriate units. Check for suppply block, rudimentary checks for enemy composition.
                 attempted_morph_larva_this_frame = true;
-                if (Reactive_Build(u, current_map_inventory, friendly_player_model.units_, enemy_player_model.units_)) {
+                if (Reactive_BuildFAP(u, current_map_inventory, friendly_player_model.units_, enemy_player_model.units_)) {
                     last_frame_of_unit_morph_command = t_game;
                 }
                 continue;
@@ -1360,10 +1358,13 @@ void CUNYAIModule::onUnitMorph( BWAPI::Unit unit )
         friendly_player_model.units_.purgeWorkerRelations(unit, land_inventory, current_map_inventory, my_reservation);
     }
 
+    if (unit->getType() == UnitTypes::Zerg_Egg || unit->getType() == UnitTypes::Zerg_Cocoon ) {
+        buildorder.updateRemainingBuildOrder(unit->getBuildType()); // Shouldn't be a problem if unit isn't in buildorder.  Don't have to worry about double-built units (lings) since the second one is not morphed as per BWAPI rules.
+    }
 
     if ( unit->getBuildType().isBuilding() ) {
         friendly_player_model.units_.purgeWorkerRelationsNoStop(unit, land_inventory, current_map_inventory, my_reservation);
-        buildorder.updateRemainingBuildOrder(unit->getBuildType());
+        buildorder.updateRemainingBuildOrder(unit->getBuildType()); // Should be caught on Morph ONLY, this might double catch them...
     }
 
     if ( unit->getType().isBuilding() && unit->getType().whatBuilds().first == UnitTypes::Zerg_Drone ) {

--- a/Source/CUNYAIModule.h
+++ b/Source/CUNYAIModule.h
@@ -116,8 +116,10 @@ public:
       TilePosition getBuildablePosition(const TilePosition target_pos, const UnitType build_type, const int tile_grid_size);
       // Moves all units except for the Stored exeption_unit elsewhere.
       void clearBuildingObstuctions(const Unit_Inventory & ui, Map_Inventory & inv, const Unit &exception_unit);
-      // checks if a unit type MUST be built next (or meets extra critera). Used in many assembly functions.
-      bool mustCreate(const Unit &unit, const UnitType &ut, const bool &extra_criteria);
+      // checks if ut is willing and able to be built next by unit. Used in many assembly functions.
+      bool checkDesirable(const Unit &unit, const UnitType &ut, const bool &extra_criteria);
+      // checks if ut is required and can be built by unit at this time.
+      bool checkFeasibleRequirement(const Unit & unit, const UnitType & ut, const bool & extra_criteria);
 
   // Mining Functions
       //Forces selected unit (drone, hopefully!) to expo:

--- a/Source/PlayerModelManager.h
+++ b/Source/PlayerModelManager.h
@@ -40,5 +40,12 @@ struct Player_Model {
     vector< int > radial_distances_from_enemy_ground_ = { 0 };
     int closest_radial_distance_enemy_ground_ = INT_MAX;
 
+    //unit cartridges, Combat unit cartridge is all mobile noneconomic units we may consider building (excludes static defense).
+    map<UnitType, int> combat_unit_cartridge_;
+    map<UnitType, int> building_cartridge_;
+    map<UpgradeType, int> upgrade_cartridge_;
+    map<TechType, int> tech_cartridge_;
+
+
 };
 

--- a/TechManager.cpp
+++ b/TechManager.cpp
@@ -9,67 +9,35 @@ using namespace BWAPI;
 // Returns true if there are any new technology improvements available at this time (new buildings, upgrades, researches, mutations).
 bool CUNYAIModule::Tech_Avail() {
 
-    for ( auto & u : BWAPI::Broodwar->self()->getUnits() ) {
+    for (auto tech : CUNYAIModule::friendly_player_model.tech_cartridge_) {
+        if (Broodwar->canResearch(tech.first))  return true; // If we can make it and don't have it.
+    }
 
-        if ( u->getType() == BWAPI::UnitTypes::Zerg_Drone ) {
-            bool long_condition = (u->canBuild( BWAPI::UnitTypes::Zerg_Spawning_Pool ) && Count_Units( BWAPI::UnitTypes::Zerg_Spawning_Pool) == 0) ||
-                    (u->canBuild( BWAPI::UnitTypes::Zerg_Evolution_Chamber ) && Count_Units( BWAPI::UnitTypes::Zerg_Evolution_Chamber) == 0) ||
-                    (u->canBuild( BWAPI::UnitTypes::Zerg_Hydralisk_Den ) && Count_Units( BWAPI::UnitTypes::Zerg_Hydralisk_Den) == 0)||
-                    (u->canBuild( BWAPI::UnitTypes::Zerg_Spire ) && Count_Units( BWAPI::UnitTypes::Zerg_Spire) == 0) ||
-                    (u->canBuild( BWAPI::UnitTypes::Zerg_Queens_Nest ) && Count_Units( BWAPI::UnitTypes::Zerg_Queens_Nest) == 0 && Count_Units( BWAPI::UnitTypes::Zerg_Spire) > 0 ) || // I have hardcoded spire before queens nest.
-                    (u->canBuild( BWAPI::UnitTypes::Zerg_Ultralisk_Cavern ) && Count_Units( BWAPI::UnitTypes::Zerg_Ultralisk_Cavern) == 0) ||
-                    (u->canBuild( BWAPI::UnitTypes::Zerg_Greater_Spire) && Count_Units(BWAPI::UnitTypes::Zerg_Greater_Spire) == 0);
-            if ( long_condition ) {
+    for (auto upgrade : CUNYAIModule::friendly_player_model.upgrade_cartridge_) {
+        bool muta_upgrade = upgrade.first == UpgradeTypes::Zerg_Flyer_Attacks || upgrade.first == UpgradeTypes::Zerg_Flyer_Carapace;
+        bool hydra_upgrade = upgrade.first == UpgradeTypes::Zerg_Missile_Attacks || upgrade.first == UpgradeTypes::Grooved_Spines || upgrade.first == UpgradeTypes::Muscular_Augments;
+        bool ling_upgrade = upgrade.first == UpgradeTypes::Zerg_Melee_Attacks || upgrade.first == UpgradeTypes::Metabolic_Boost;
+
+        if ((muta_upgrade || hydra_upgrade || ling_upgrade) && Broodwar->canUpgrade(upgrade.first)) {
+
+            bool upgrade_conditionals = (hydra_upgrade && Stock_Units(UnitTypes::Zerg_Hydralisk, friendly_player_model.units_) > Stock_Units(UnitTypes::Zerg_Zergling, friendly_player_model.units_)) ||
+                (ling_upgrade && Stock_Units(UnitTypes::Zerg_Hydralisk, friendly_player_model.units_) < Stock_Units(UnitTypes::Zerg_Zergling, friendly_player_model.units_)) ||
+                (muta_upgrade && friendly_player_model.units_.stock_fliers_ > Stock_Units(UnitTypes::Zerg_Hydralisk, friendly_player_model.units_));
+
+            if (upgrade_conditionals) { // if it is not maxed, and nothing is upgrading it, then there must be some tech work we could do. We do not require air upgrades at this time, but they could still plausibly occur.
                 return true;
             }
         }
-        else if ( (u->getType() == BWAPI::UnitTypes::Zerg_Hatchery || u->getType() == BWAPI::UnitTypes::Zerg_Lair || u->getType() == BWAPI::UnitTypes::Zerg_Hive) && !u->isUpgrading() && !u->isMorphing() ) {
-            bool long_condition = (u->canMorph( BWAPI::UnitTypes::Zerg_Lair ) && Count_Units( BWAPI::UnitTypes::Zerg_Lair) == 0 && Count_Units( BWAPI::UnitTypes::Zerg_Hive) == 0) ||
-                    (u->canMorph( BWAPI::UnitTypes::Zerg_Hive ) && Count_Units( BWAPI::UnitTypes::Zerg_Hive) == 0);
-            if ( long_condition ) {
-                return true;
-            }
-        }
-        else if ( u->getType().isBuilding() && !u->isUpgrading() && !u->isMorphing() ){ // check idle buildings for potential upgrades.
-            for ( int i = 0; i != 13; i++ )
-            { // iterating through the main upgrades we have available and CUNYAI "knows" about. 
-                int known_ups[13] = { 3, 4, 10, 11, 12, 25, 26, 27, 28, 29, 30, 52, 53 }; // Identifies zerg upgrades of that we have initialized at this time. See UpgradeType definition for references, listed below for conveinence.
-                UpgradeType up_current = (UpgradeType) known_ups[i];
-                UpgradeType::set building_up_set = u->getType().upgradesWhat(); // does this idle building make that upgrade?
-                if ( building_up_set.find( up_current ) != building_up_set.end() ) {
+        else if (Broodwar->canUpgrade(upgrade.first)) return true; // If we can make it and don't have it.
+    }
 
-                    bool upgrade_incomplete = BWAPI::Broodwar->self()->getUpgradeLevel(up_current) < up_current.maxRepeats() && !BWAPI::Broodwar->self()->isUpgrading(up_current);
-
-                    bool hydra_upgrade = up_current == UpgradeTypes::Zerg_Missile_Attacks || up_current == UpgradeTypes::Grooved_Spines || up_current == UpgradeTypes::Muscular_Augments;
-                    bool ling_upgrade = up_current == UpgradeTypes::Zerg_Melee_Attacks || up_current == UpgradeTypes::Metabolic_Boost;
-
-                    bool upgrade_conditionals = ( hydra_upgrade && Stock_Units(UnitTypes::Zerg_Hydralisk, friendly_player_model.units_) > Stock_Units(UnitTypes::Zerg_Zergling, friendly_player_model.units_)) ||
-                        (ling_upgrade && Stock_Units(UnitTypes::Zerg_Hydralisk, friendly_player_model.units_) < Stock_Units(UnitTypes::Zerg_Zergling, friendly_player_model.units_));
-
-                    if (upgrade_incomplete && upgrade_conditionals) { // if it is not maxed, and nothing is upgrading it, then there must be some tech work we could do. We do not require air upgrades at this time, but they could still plausibly occur.
-                        return true;
-                    }
-                }
-            }
-        } // if condition
-        else if ( u->getType().isBuilding() && !u->isUpgrading() && !u->isMorphing() ) { // check idle buildings for potential upgrades.
-            for ( int i = 0; i != 1; i++ )
-            { // iterating through the main researches we have available and CUNYAI "knows" about. 
-                int known_techs[1] = { 32 }; // Identifies zerg upgrades of that we have initialized at this time. See UpgradeType definition for references, listed below for conveinence.
-                TechType tech_current = (TechType)known_techs[i];
-                TechType::set building_tech_set = u->getType().researchesWhat(); // does this idle building make that upgrade?
-                if ( building_tech_set.find( tech_current ) != building_tech_set.end() ) {
-                    bool tech_incomplete = Broodwar->self()->hasResearched( tech_current );
-                    if ( tech_incomplete ) { // if it is not maxed, and nothing is upgrading it, then there must be some tech work we could do.
-                        return true;
-                    }
-                }
-            }
-        } // if condition
-    }// for every unit
+    for (auto building : CUNYAIModule::friendly_player_model.building_cartridge_) {
+        if(Broodwar->canMake(building.first) && Count_Units(building.first) == 0) return true; // If we can make it and don't have it.
+    }
 
     return false;
 }
+
 // Tells a building to begin the next tech on our list. Now updates the unit if something has changed.
 bool CUNYAIModule::Tech_Begin(Unit building, Unit_Inventory &ui, const Map_Inventory &inv) {
     bool busy = false;
@@ -83,7 +51,7 @@ bool CUNYAIModule::Tech_Begin(Unit building, Unit_Inventory &ui, const Map_Inven
     bool maxed_armor = BWAPI::Broodwar->self()->getUpgradeLevel(UpgradeTypes::Zerg_Carapace) == 3;
 
     bool more_hydras_than_lings = Stock_Units(UnitTypes::Zerg_Hydralisk, friendly_player_model.units_) > Stock_Units(UnitTypes::Zerg_Zergling, friendly_player_model.units_);
-    bool more_flyers_than_ground = ui.stock_fliers_ > ui.stock_ground_units_;
+    bool more_flyers_than_hydras = ui.stock_fliers_ > Stock_Units(UnitTypes::Zerg_Hydralisk, friendly_player_model.units_);
 
     // Major Upgrades:
     if (!busy) busy = Check_N_Upgrade(UpgradeTypes::Metabolic_Boost, building, upgrade_bool && Stock_Units(UnitTypes::Zerg_Zergling, friendly_player_model.units_) > 0);
@@ -107,8 +75,8 @@ bool CUNYAIModule::Tech_Begin(Unit building, Unit_Inventory &ui, const Map_Inven
     if (!busy) busy = Check_N_Upgrade(UpgradeTypes::Zerg_Carapace, building, upgrade_bool);
     if (!busy) busy = Check_N_Upgrade(UpgradeTypes::Zerg_Melee_Attacks, building, upgrade_bool && !more_hydras_than_lings  || maxed_range);
     if (!busy) busy = Check_N_Upgrade(UpgradeTypes::Zerg_Missile_Attacks, building, upgrade_bool && more_hydras_than_lings || maxed_melee);
-    if (!busy) busy = Check_N_Upgrade(UpgradeTypes::Zerg_Flyer_Attacks, building, upgrade_bool && Count_Units(UnitTypes::Zerg_Spire) > 0 && (more_flyers_than_ground || maxed_armor));
-    if (!busy) busy = Check_N_Upgrade(UpgradeTypes::Zerg_Flyer_Carapace, building, upgrade_bool && Count_Units(UnitTypes::Zerg_Spire) > 0 && (more_flyers_than_ground || maxed_armor));
+    if (!busy) busy = Check_N_Upgrade(UpgradeTypes::Zerg_Flyer_Attacks, building, upgrade_bool && Count_Units(UnitTypes::Zerg_Spire) > 0 && (more_flyers_than_hydras || maxed_armor));
+    if (!busy) busy = Check_N_Upgrade(UpgradeTypes::Zerg_Flyer_Carapace, building, upgrade_bool && Count_Units(UnitTypes::Zerg_Spire) > 0 && (more_flyers_than_hydras || maxed_armor));
 
     //should auto upgrade if there is a build order requirement for any of these three types.
   if(!busy) busy = Check_N_Build(UnitTypes::Zerg_Lair, building, upgrade_bool &&

--- a/Unit_Inventory.cpp
+++ b/Unit_Inventory.cpp
@@ -111,9 +111,10 @@ void Unit_Inventory::purgeAllPhases()
 void Unit_Inventory::purgeWorkerRelations(const Unit &unit, Resource_Inventory &ri, Map_Inventory &inv, Reservation &res)
 {
     UnitCommand command = unit->getLastCommand();
-    auto found_position = this->unit_inventory_.find(unit);
-    if (found_position != this->unit_inventory_.end()) {
-        Stored_Unit& miner = found_position->second;
+    auto found_object = this->unit_inventory_.find(unit);
+    if (found_object != this->unit_inventory_.end()) {
+        Stored_Unit& miner = found_object->second;
+
         miner.stopMine(ri);
 
         if (command.getType() == UnitCommandTypes::Morph || command.getType() == UnitCommandTypes::Build) {
@@ -135,9 +136,10 @@ void Unit_Inventory::purgeWorkerRelations(const Unit &unit, Resource_Inventory &
 void Unit_Inventory::purgeWorkerRelationsNoStop(const Unit &unit, Resource_Inventory &ri, Map_Inventory &inv, Reservation &res)
 {
     UnitCommand command = unit->getLastCommand();
-    auto found_position = this->unit_inventory_.find(unit);
-    if (found_position != this->unit_inventory_.end() ) {
-        Stored_Unit& miner = found_position->second;
+    auto found_object = this->unit_inventory_.find(unit);
+    if (found_object != this->unit_inventory_.end()) {
+        Stored_Unit& miner = found_object->second;
+
         miner.stopMine(ri);
 
         if (command.getType() == UnitCommandTypes::Morph || command.getType() == UnitCommandTypes::Build) {
@@ -260,16 +262,16 @@ void Stored_Unit::updateStoredUnit(const Unit &unit){
         stock_value_ = shell.stock_value_; // longer but prevents retyping.
         circumference_ = shell.circumference_;
         circumference_remaining_ = shell.circumference_;
-        future_fap_value_ = CUNYAIModule::IsFightingUnit(unit) * shell.stock_value_; //Updated in updateFAPvalue(), this is simply a natural placeholder.
+        future_fap_value_ = shell.stock_value_; //Updated in updateFAPvalue(), this is simply a natural placeholder.
         current_stock_value_ = static_cast<int>(stock_value_ * current_hp_ / static_cast<double>(type_.maxHitPoints() + type_.maxShields())); 
-        ma_future_fap_value_ = CUNYAIModule::IsFightingUnit(unit) * shell.stock_value_;
+        ma_future_fap_value_ = shell.stock_value_;
     }
     else {
         bool retreating_or_undetected = (/*phase_ == "Retreating" ||*/ phase_ == "Pathing Out" || phase_ == "Pathing In" || (burrowed_ && !detected_));
         double weight = (_MOVING_AVERAGE_DURATION - 1) / static_cast<double>(_MOVING_AVERAGE_DURATION);
         circumference_remaining_ = circumference_;
         current_stock_value_ = static_cast<int>(stock_value_ * current_hp_ / static_cast<double>(type_.maxHitPoints() + type_.maxShields())); 
-        ma_future_fap_value_ = (CUNYAIModule::IsFightingUnit(unit) * retreating_or_undetected) ? current_stock_value_ : static_cast<int>(round(weight * ma_future_fap_value_ + (1 - weight) * future_fap_value_));
+        ma_future_fap_value_ = retreating_or_undetected ? current_stock_value_ : static_cast<int>(weight * ma_future_fap_value_ + (1.0 - weight) * future_fap_value_);
     }
 }
 
@@ -610,13 +612,14 @@ Stored_Unit::Stored_Unit(const UnitType &unittype) {
         modified_supply_ = 0;
     }
 
+
     stock_value_ = static_cast<int>(modified_min_cost_ + 1.25 * modified_gas_cost_ + 25 * modified_supply_);
 
     stock_value_ /= (1 + static_cast<int>(unittype.isTwoUnitsInOneEgg())); // condensed /2 into one line to avoid if-branch prediction.
 
     current_stock_value_ = stock_value_; // Precalculated, precached.
-    future_fap_value_ = CUNYAIModule::IsFightingUnit(unittype) * stock_value_;
-    ma_future_fap_value_ = CUNYAIModule::IsFightingUnit(unittype) * stock_value_;
+    future_fap_value_ = stock_value_;
+    ma_future_fap_value_ = stock_value_;
 };
 
 // We must be able to create Stored_Unit objects as well.
@@ -651,10 +654,11 @@ Stored_Unit::Stored_Unit( const Unit &unit ) {
         modified_gas_cost_ = shell.modified_gas_cost_;
         modified_supply_ = shell.modified_supply_;
         stock_value_ = shell.stock_value_; //prevents retyping.
-        ma_future_fap_value_ = CUNYAIModule::IsFightingUnit(unit) * shell.stock_value_;
-        future_fap_value_ = CUNYAIModule::IsFightingUnit(unit) * shell.stock_value_;
+        ma_future_fap_value_ = shell.stock_value_;
+        future_fap_value_ = shell.stock_value_;
 
     current_stock_value_ = static_cast<int>(stock_value_ * current_hp_ / static_cast<double>( type_.maxHitPoints() + type_.maxShields() ) ); // Precalculated, precached.
+
 }
 
 
@@ -870,8 +874,10 @@ auto Stored_Unit::convertToFAPPosition(const Position &chosen_pos, const Researc
 
 void Stored_Unit::updateFAPvalue(FAP::FAPUnit<Stored_Unit*> &fap_unit)
 {
+
     double proportion_health = (fap_unit.health + fap_unit.shields) / static_cast<double>(fap_unit.maxHealth + fap_unit.maxShields);
-    fap_unit.data->future_fap_value_ = static_cast<int>(fap_unit.data->stock_value_ * proportion_health); // if you are retreating, we assume you preserve your health.
+    fap_unit.data->future_fap_value_ = static_cast<int>(fap_unit.data->stock_value_ * proportion_health); 
+
     fap_unit.data->updated_fap_this_frame_ = true;
 }
 
@@ -912,6 +918,20 @@ void Unit_Inventory::addToBuildFAP( FAP::FastAPproximation<Stored_Unit*> &fap_ob
         Position pos = positionBuildFap(friendly);
         if(friendly) fap_object.addIfCombatUnitPlayer1(u.second.convertToFAPPosition(pos, ri));
         else if(!u.second.type_.isBuilding()) fap_object.addIfCombatUnitPlayer2(u.second.convertToFAPPosition(pos, ri));
+    }
+
+    Position pos = positionBuildFap(friendly);
+    if (friendly) {
+        fap_object.addIfCombatUnitPlayer1(Stored_Unit(Broodwar->self()->getRace().getResourceDepot()).convertToFAPPosition(Position{ 240,240 }, ri));
+        for (auto i = 0; i <= 5; i++) {
+            fap_object.addIfCombatUnitPlayer1(Stored_Unit(Broodwar->self()->getRace().getSupplyProvider()).convertToFAPPosition(Position{ 240,240 }, ri));
+        }
+    }
+    else {
+        fap_object.addIfCombatUnitPlayer2(Stored_Unit(Broodwar->enemy()->getRace().getResourceDepot()).convertToFAPPosition(Position{ 0, 0 }, ri));
+        for (auto i = 0; i <= 5; i++) {
+            fap_object.addIfCombatUnitPlayer2(Stored_Unit(Broodwar->enemy()->getRace().getSupplyProvider()).convertToFAPPosition(Position{ 0, 0 }, ri));
+        }
     }
 }
 

--- a/Utilities.cpp
+++ b/Utilities.cpp
@@ -85,7 +85,7 @@ bool CUNYAIModule::IsFightingUnit(const Unit &unit)
 
     // no workers or buildings allowed. Or overlords, or larva..
     if ( unit && u_type.isWorker() ||
-        u_type.isBuilding() ||
+        //u_type.isBuilding() ||
         u_type == BWAPI::UnitTypes::Zerg_Larva ||
         u_type == BWAPI::UnitTypes::Zerg_Overlord )
     {
@@ -94,9 +94,12 @@ bool CUNYAIModule::IsFightingUnit(const Unit &unit)
 
     // This is a last minute check for psi-ops. I removed a bunch of these. Observers and medics are not combat units per se.
     if (u_type.canAttack() ||
-        u_type == BWAPI::UnitTypes::Protoss_High_Templar ||
+        u_type.maxEnergy() > 0 ||
+        u_type.isDetector() ||
         u_type == BWAPI::UnitTypes::Terran_Bunker ||
-        (u_type.isFlyer() && u_type.spaceProvided()) )
+        u_type.spaceProvided() ||
+        u_type == BWAPI::UnitTypes::Protoss_Carrier ||
+        u_type == BWAPI::UnitTypes::Protoss_Reaver)
     {
         return true;
     }
@@ -126,7 +129,9 @@ bool CUNYAIModule::IsFightingUnit(const Stored_Unit &unit)
         unit.type_.maxEnergy() > 0 ||
         unit.type_.isDetector() ||
         unit.type_ == BWAPI::UnitTypes::Terran_Bunker ||
-        (unit.type_.isFlyer() && unit.type_.spaceProvided()))
+        unit.type_.spaceProvided() ||
+        unit.type_ == BWAPI::UnitTypes::Protoss_Carrier ||
+        unit.type_ == BWAPI::UnitTypes::Protoss_Reaver)
     {
         return true;
     }
@@ -152,7 +157,9 @@ bool CUNYAIModule::IsFightingUnit(const UnitType &unittype)
         unittype.maxEnergy() > 0 ||
         unittype.isDetector() ||
         unittype == BWAPI::UnitTypes::Terran_Bunker ||
-        (unittype.isFlyer() && unittype.spaceProvided()) )
+        unittype.spaceProvided() ||
+        unittype == BWAPI::UnitTypes::Protoss_Carrier ||
+        unittype == BWAPI::UnitTypes::Protoss_Reaver)
     {
         return true;
     }


### PR DESCRIPTION
Macro:

* Fixed bug in build order system (#112)
Causing build order hatcheries to always be built as macro hatches, when they -never- ought to be.
* BuildFAP Fixes
* Performance considerations: BuildFAP could be massively expensive at times, a few freezeups as well. Building suggestions tend to collapse if the simulations are particularly one-sided.
* Standardized BuildFAP sizes between maps
* Performance flourish for morphing static defense.
* Fixed bug where BuildFAP missed first element under consideration.
* Update AssemblyManager.cpp to depend on relatively agnostic "cartridges" of units, buildings, and upgrades , or researches rather than hard-coded considerations. This way, students can replace them when they want to restrict unit choices.  (ie on exploitive build orders, or in zvz when lurkers are not wanted.)
* BuildFAP will no longer neglect the possibility of a hydra -staying as a hydra- when considering build options.
* Removed script for lings potentially causing suicidal behavior.
* Found bug in Stored_Unit(UnitType) leading to bad buildFAP choices.
* Fixed a bug causing some attack orders to be lost.
* Several changes to static D logic (less based off of sim, more based off actually present units.
* Fixed bug in K/L ratio.
* Consolidated Build Order Removals- now all take place OnMorph.
* Fixed bug causing hardcoded build order sunkens (or spores) not to build when enemy was not discovered.
* Adding a default level of assumed background units to BuildFAP, eg, there is some value in having anti-air power and there is some value in having anti-ground power- even if the enemy appears to lack those forces.
* In this most recent branch, a pack of lings no longer counts as "ling ling" so the build orders have been simplified to match.
* More precisely specified macro hatch logic, much less common now.

Micro:
* Adapt to use FAP built-ins better
* Carriers: Assumes pre-loaded carriers, Interceptors are now worth $0 independently.
* Fixed a retreat/attack loop. If I entered the loop already and am not attacking, I must retreat.
* Working with MAFAP: fixed bugs in MAFAP averaging system.
* Units now are considered as "survivors" of MC_FAP at current HP if they are retreating or not in the combat "zone". Could do more elegantly by removing them from the sim, perhaps.
* Units now fight when enemies are near home.
* Fixed bug: Can_Fight had an omission of reavers being able to fight ground.
* No longer build sim against enemy buildings (extending sim, causing overvaluation of ranged units).
* Fixed bug causing units to run from units that are not a threat.
* Zerglings may have been suiciding because their MA fap value was low (unlikely to survive fight), and proportionally they were likely to do more damage to their opponent than they were to receive (lings would stay at 0% MAfap while opponent may drop from 50% to 45%), and consider this a normal trade.
* Found and fixed a subtle int-double subtraction causing units to maintain inappropriately high MA_FAP value. This bug was less visible on ranged units since they tend to stay at higher MAfap values.

Diagnostics: 
* Improved HP and MA_FAP displays. Note: Display behavior may be surprising on morphing buildings, but this is due to their unique state in bwapi, not due to some bugged feature of the display.
* Display now announces if weak vs air is returning TRUE or not.
* Tested FAP in small cases.
* Removed a small bug in "phase_" display.

Cleanup:
* Removed depreciated functions.
* Moved the MAFAP calculation into the body of updateStoredUnit.
* Standardizing MA_FAP style in Sunken Production
* Fixed rare bug causing crash on loss when bot has no units.
* Commented out some defunct bools.
* Refactored evalArmy() and evalTech() functions. Almost pure refactoring. Should be much faster, removed a loop through the original bwapi unit storage system.
* Fixed some rare crashes.