### PR TITLE
On frame refactor

### DIFF
--- a/AssemblyManager.cpp
+++ b/AssemblyManager.cpp
@@ -787,16 +787,14 @@ bool AssemblyManager::testActiveAirDefenseBest(const bool testSelf) const {
             baselineWithSunks.addExtraUnitToSimulation(su, testSelf); //add unit we are interested in to the inventory:
         }
         baselineWithSunks.runSimulation();
-        int gainInBaseline = baselineWithSunks.getScoreGap(testSelf);
 
         // test fake anti-air sunkens
         CombatSimulator baselineWithSpores = buildSim;
-        StoredUnit su = StoredUnit(UnitTypes::Zerg_Spore_Colony);
+        StoredUnit su2 = StoredUnit(UnitTypes::Zerg_Spore_Colony);
         // enemy units do not change.
         for (int i = 0; i < 5; ++i) {
-            baselineWithSpores.addExtraUnitToSimulation(su, testSelf); //add unit we are interested in to the inventory:
+            baselineWithSpores.addExtraUnitToSimulation(su2, testSelf); //add unit we are interested in to the inventory:
         }
-        int gainInBaseline = baselineWithSpores.getScoreGap();
         baselineWithSpores.runSimulation();
 
         return baselineWithSpores.getScoreGap(testSelf) >= baselineWithSunks.getScoreGap(testSelf);
@@ -819,16 +817,14 @@ bool AssemblyManager::testAirAttackBest(const bool testSelf) const {
         baselineWithHydras.addExtraUnitToSimulation(su, testSelf); //add unit we are interested in to the inventory:
     }
     baselineWithHydras.runSimulation();
-    int gainInBaseline = baselineWithHydras.getScoreGap(testSelf);
 
     // test mutalisks
     CombatSimulator baselineWithMutas = buildSim;
-    StoredUnit su = StoredUnit(UnitTypes::Zerg_Mutalisk);
+    StoredUnit su2 = StoredUnit(UnitTypes::Zerg_Mutalisk);
     // enemy units do not change.
     for (int i = 0; i < 33; ++i) {
-        baselineWithMutas.addExtraUnitToSimulation(su, testSelf); //add unit we are interested in to the inventory:
+        baselineWithMutas.addExtraUnitToSimulation(su2, testSelf); //add unit we are interested in to the inventory:
     }
-    int gainInBaseline = baselineWithMutas.getScoreGap();
     baselineWithMutas.runSimulation();
 
     return baselineWithMutas.getScoreGap(testSelf) >= baselineWithHydras.getScoreGap(testSelf);

--- a/AssemblyManager.cpp
+++ b/AssemblyManager.cpp
@@ -473,7 +473,7 @@ bool AssemblyManager::reserveOptimalCombatUnit(const Unit &morph_canidate, map<U
     return false;
 }
 
-void AssemblyManager::weightUnitSim(const bool & condition, const UnitType & unit, const double & weight)
+void AssemblyManager::weightUnitSim(const bool & condition, const UnitType & unit, const int & weight)
 {
     if (condition)
         if (assemblyCycle_.find(unit) != assemblyCycle_.end())

--- a/BaseManager.cpp
+++ b/BaseManager.cpp
@@ -1,6 +1,7 @@
 #include <BWAPI.h>
 #include "Source/CUNYAIModule.h"
 #include "Source/Diagnostics.h"
+#include "Source/UnitInventory.h"
 #include "Source/AssemblyManager.h"
 #include "Source/MobilityManager.h"
 

--- a/Build.cpp
+++ b/Build.cpp
@@ -6,6 +6,7 @@
 #include "Source\CUNYAIModule.h"
 #include "Source\Build.h"
 #include "Source\Diagnostics.h"
+#include "Source\UnitInventory.h"
 #include <string>
 
 

--- a/CUNYAIModule.cpp
+++ b/CUNYAIModule.cpp
@@ -56,7 +56,6 @@ Reservation CUNYAIModule::my_reservation;
 LearningManager CUNYAIModule::learnedPlan;
 WorkerManager CUNYAIModule::workermanager;
 BaseManager CUNYAIModule::basemanager;
-CombatSimulator CUNYAIModule::mainCombatSim;
 
 double CUNYAIModule::supply_ratio = 0; // for supply levels.  Supply is an inhibition on growth rather than a resource to spend.  Cost of growth.
 double CUNYAIModule::gas_proportion = 0; // for gas levels. Gas is critical for spending but will be matched with supply.

--- a/CUNYAIModule.cpp
+++ b/CUNYAIModule.cpp
@@ -172,14 +172,12 @@ void CUNYAIModule::onFrame()
     // Update Players:
     enemy_player_model.updateOtherOnFrame(Broodwar->enemy());
     friendly_player_model.updateSelfOnFrame(); 
-    Diagnostics::drawAllSpamGuards(friendly_player_model.units_);
     //Update neutral units
     Player* neutral_player;
     for (auto p : Broodwar->getPlayers()) {
         if (p->isNeutral()) neutral_player = &p;
     }
     neutral_player_model.updateOtherOnFrame(*neutral_player);
-    Diagnostics::drawAllHitPoints(neutral_player_model.units_);
     //Draw Diagnostics
     enemy_player_model.units_.drawAllLocations();
     enemy_player_model.units_.drawAllLastSeens();
@@ -214,12 +212,18 @@ void CUNYAIModule::onFrame()
     workerOnFrame.clockFinish("Workers Updated");
 
     //Update Map.
+    DiagnosticTimer mapOnFrame;
     currentMapInventory.onFrame();
+    mapOnFrame.clockFinish("Map Updated");
 
     //Update Resources.
+    DiagnosticTimer landOnFrame;
     land_inventory.onFrame();
+    landOnFrame.clockFinish("Land Resources Updated");
 
+    DiagnosticTimer basesOnFrame;
     basemanager.updateBases();
+    basesOnFrame.clockFinish("Bases Updated");
 
     Diagnostics::onFrameWritePlayerModel(friendly_player_model);
 

--- a/CUNYAIModule.cpp
+++ b/CUNYAIModule.cpp
@@ -25,9 +25,6 @@
 #include <stdio.h>  //for removal of files.
 #include <filesystem>
 
-
-// CUNYAI V2.00
-
 using namespace BWAPI;
 using namespace Filter;
 using namespace std;

--- a/CUNYAIModule.cpp
+++ b/CUNYAIModule.cpp
@@ -247,7 +247,7 @@ void CUNYAIModule::onFrame()
     }
 
     my_reservation.confirmOngoingReservations();
-    Diagnostics::drawReservations(my_reservation, currentMapInventory.screen_position_);
+    Diagnostics::drawReservations(my_reservation, Broodwar->getScreenPosition());
 
 
 
@@ -320,14 +320,14 @@ void CUNYAIModule::onFrame()
                     Position closest_loc_to_c_that_gives_vision = Position(c.x + static_cast<int>(cos(theta) * 0.75) * detector_of_choice.type_.sightRange(), c.y + static_cast<int>(sin(theta) * 0.75) * detector_of_choice.type_.sightRange());
                     if (closest_loc_to_c_that_gives_vision.isValid() && closest_loc_to_c_that_gives_vision != Positions::Origin) {
                         detector_of_choice.bwapi_unit_->move(closest_loc_to_c_that_gives_vision);
-                        Diagnostics::drawCircle(c, CUNYAIModule::currentMapInventory.screen_position_, 25, Colors::Cyan);
-                        Diagnostics::drawLine(detector_of_choice.pos_, closest_loc_to_c_that_gives_vision, currentMapInventory.screen_position_, Colors::Cyan);
+                        Diagnostics::drawCircle(c, Broodwar->getScreenPosition(), 25, Colors::Cyan);
+                        Diagnostics::drawLine(detector_of_choice.pos_, closest_loc_to_c_that_gives_vision, Broodwar->getScreenPosition(), Colors::Cyan);
                         CUNYAIModule::updateUnitPhase(detector_of_choice.bwapi_unit_, StoredUnit::Phase::Detecting); // Update the detector not the calling unit.
                     }
                     else {
                         detector_of_choice.bwapi_unit_->move(c);
-                        Diagnostics::drawCircle(c, CUNYAIModule::currentMapInventory.screen_position_, 25, Colors::Cyan);
-                        Diagnostics::drawLine(detector_of_choice.pos_, currentMapInventory.screen_position_, c, Colors::Cyan);
+                        Diagnostics::drawCircle(c, Broodwar->getScreenPosition(), 25, Colors::Cyan);
+                        Diagnostics::drawLine(detector_of_choice.pos_, Broodwar->getScreenPosition(), c, Colors::Cyan);
                         CUNYAIModule::updateUnitPhase(detector_of_choice.bwapi_unit_, StoredUnit::Phase::Detecting);  // Update the detector not the calling unit.
                     }
                 }

--- a/CUNYAIModule.vcxproj
+++ b/CUNYAIModule.vcxproj
@@ -111,6 +111,7 @@
     <ClCompile Include="Build.cpp" />
     <ClCompile Include="CobbDouglas.cpp" />
     <ClCompile Include="CombatManager.cpp" />
+    <ClCompile Include="CombatSimulator.cpp" />
     <ClCompile Include="CUNYAIModule.cpp" />
     <ClCompile Include="CUNYClient.cpp" />
     <ClCompile Include="Diagnostics.cpp" />
@@ -145,6 +146,7 @@
     <ClInclude Include="Source\BWEB\Wall.h" />
     <ClInclude Include="Source\CobbDouglas.h" />
     <ClInclude Include="Source\CombatManager.h" />
+    <ClInclude Include="Source\CombatSimulator.h" />
     <ClInclude Include="Source\CUNYAIModule.h" />
     <ClInclude Include="Source\Diagnostics.h" />
     <ClInclude Include="Source\MobilityManager.h" />

--- a/CUNYAIModule.vcxproj.filters
+++ b/CUNYAIModule.vcxproj.filters
@@ -74,6 +74,9 @@
     <ClCompile Include="Build.cpp">
       <Filter>Utilities</Filter>
     </ClCompile>
+    <ClCompile Include="CombatSimulator.cpp">
+      <Filter>Utilities</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Source\CobbDouglas.h" />
@@ -112,6 +115,7 @@
     <ClInclude Include="Utilities.h" />
     <ClInclude Include="Source\ResourceInventory.h" />
     <ClInclude Include="Source\Build.h" />
+    <ClInclude Include="Source\CombatSimulator.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Utilities">

--- a/CombatManager.cpp
+++ b/CombatManager.cpp
@@ -349,8 +349,8 @@ void CombatManager::onFrame()
     CUNYAIModule::friendly_player_model.units_.updateWithPredictedStatus(mainCombatSim);
     CUNYAIModule::enemy_player_model.units_.updateWithPredictedStatus(mainCombatSim, false);
 
-    Diagnostics::drawAllFutureDeaths(CUNYAIModule::friendly_player_model.units_);
-    Diagnostics::drawAllFutureDeaths(CUNYAIModule::enemy_player_model.units_);
+    Diagnostics::drawAllMAFAPaverages(CUNYAIModule::friendly_player_model.units_);
+    Diagnostics::drawAllMAFAPaverages(CUNYAIModule::enemy_player_model.units_);
 
 }
 

--- a/CombatManager.cpp
+++ b/CombatManager.cpp
@@ -346,8 +346,8 @@ void CombatManager::onFrame()
     // Update FAPS with units, runs sim, and reports issues.
     CUNYAIModule::mainCombatSim.addPlayersToSimulation();
     CUNYAIModule::mainCombatSim.runSimulation();
-    CUNYAIModule::friendly_player_model.units_.updatePredictedStatus(CUNYAIModule::mainCombatSim.getFriendlySim());
-    CUNYAIModule::enemy_player_model.units_.updatePredictedStatus(CUNYAIModule::mainCombatSim.getEnemySim());
+    CUNYAIModule::friendly_player_model.units_.updatePredictedStatus();
+    CUNYAIModule::enemy_player_model.units_.updatePredictedStatus(false);
 
     Diagnostics::drawAllFutureDeaths(CUNYAIModule::friendly_player_model.units_);
     Diagnostics::drawAllFutureDeaths(CUNYAIModule::enemy_player_model.units_);

--- a/CombatManager.cpp
+++ b/CombatManager.cpp
@@ -7,11 +7,13 @@
 #include "Source\CombatSimulator.h"
 #include "Source\UnitInventory.h"
 #include "Source\Diagnostics.h"
+#include "Source/FAP/FAP/include/FAP.hpp"
 #include <bwem.h>
 
 
 UnitInventory CombatManager::scout_squad_;
 UnitInventory CombatManager::liabilities_squad_;
+CombatSimulator CUNYAIModule::mainCombatSim;
 
 bool CombatManager::grandStrategyScript(const Unit & u) {
 
@@ -347,8 +349,8 @@ void CombatManager::onFrame()
     CUNYAIModule::friendly_player_model.units_.updatePredictedStatus(CUNYAIModule::mainCombatSim.getFriendlySim());
     CUNYAIModule::enemy_player_model.units_.updatePredictedStatus(CUNYAIModule::mainCombatSim.getEnemySim());
 
-    Diagnostics::drawAllFutureDeaths(enemy.units_);
-    Diagnostics::drawAllFutureDeaths(friendly.units_);
+    Diagnostics::drawAllFutureDeaths(CUNYAIModule::friendly_player_model.units_);
+    Diagnostics::drawAllFutureDeaths(CUNYAIModule::enemy_player_model.units_);
 
 }
 

--- a/CombatManager.cpp
+++ b/CombatManager.cpp
@@ -58,7 +58,7 @@ bool CombatManager::combatScript(const Unit & u)
         int search_radius = getSearchRadius(u);
 
         //if(!u->getType().isWorker())
-        //    Diagnostics::drawCircle(u->getPosition(), CUNYAIModule::currentMapInventory.screen_position_, search_radius, Colors::Green);
+        //    Diagnostics::drawCircle(u->getPosition(), Broodwar->getScreenPosition(), search_radius, Colors::Green);
 
         UnitInventory enemy_loc = CUNYAIModule::getUnitInventoryInRadius(CUNYAIModule::enemy_player_model.units_, u->getPosition(), search_radius);
         UnitInventory friend_loc = CUNYAIModule::getUnitInventoryInRadius(CUNYAIModule::friendly_player_model.units_, u->getPosition(), search_radius);
@@ -87,8 +87,8 @@ bool CombatManager::combatScript(const Unit & u)
             friend_loc.updateUnitInventorySummary();
             enemy_loc.updateUnitInventorySummary();
 
-            //Diagnostics::drawCircle(e_closest_demanding_response->pos_, CUNYAIModule::currentMapInventory.screen_position_, CUNYAIModule::enemy_player_model.units_.max_range_, Colors::Red);
-            //Diagnostics::drawCircle(e_closest_demanding_response->pos_, CUNYAIModule::currentMapInventory.screen_position_, search_radius, Colors::Green);
+            //Diagnostics::drawCircle(e_closest_demanding_response->pos_, Broodwar->getScreenPosition(), CUNYAIModule::enemy_player_model.units_.max_range_, Colors::Red);
+            //Diagnostics::drawCircle(e_closest_demanding_response->pos_, Broodwar->getScreenPosition(), search_radius, Colors::Green);
 
             //If we can fight, our unit type will determine our behavior.
             if (CUNYAIModule::canContributeToFight(u->getType(), enemy_loc)) {

--- a/CombatManager.cpp
+++ b/CombatManager.cpp
@@ -5,6 +5,7 @@
 #include "Source\MobilityManager.h"
 #include "Source\CombatManager.h"
 #include "Source\CombatSimulator.h"
+#include "Source\UnitInventory.h"
 #include "Source\Diagnostics.h"
 #include <bwem.h>
 

--- a/CombatManager.cpp
+++ b/CombatManager.cpp
@@ -13,7 +13,6 @@
 
 UnitInventory CombatManager::scout_squad_;
 UnitInventory CombatManager::liabilities_squad_;
-CombatSimulator CUNYAIModule::mainCombatSim;
 
 bool CombatManager::grandStrategyScript(const Unit & u) {
 

--- a/CombatManager.cpp
+++ b/CombatManager.cpp
@@ -343,10 +343,11 @@ int CombatManager::getSearchRadius(const Unit & u)
 void CombatManager::onFrame()
 {
     // Update FAPS with units, runs sim, and reports issues.
-    CUNYAIModule::mainCombatSim.addPlayersToSimulation();
-    CUNYAIModule::mainCombatSim.runSimulation();
-    CUNYAIModule::friendly_player_model.units_.updatePredictedStatus();
-    CUNYAIModule::enemy_player_model.units_.updatePredictedStatus(false);
+    CombatSimulator mainCombatSim;
+    mainCombatSim.addPlayersToSimulation();
+    mainCombatSim.runSimulation();
+    CUNYAIModule::friendly_player_model.units_.updateWithPredictedStatus(mainCombatSim);
+    CUNYAIModule::enemy_player_model.units_.updateWithPredictedStatus(mainCombatSim, false);
 
     Diagnostics::drawAllFutureDeaths(CUNYAIModule::friendly_player_model.units_);
     Diagnostics::drawAllFutureDeaths(CUNYAIModule::enemy_player_model.units_);

--- a/CombatSimulator.cpp
+++ b/CombatSimulator.cpp
@@ -10,7 +10,7 @@ double CombatSimulator::unitWeight(FAP::FAPUnit<StoredUnit*> FAPunit)
     return  FAPunit.data->stock_value_ * static_cast<double>(FAPunit.health + FAPunit.shields) / static_cast<double>(FAPunit.maxHealth + FAPunit.maxShields);
 }
 
-auto CombatSimulator::createFAPVersion(const StoredUnit u,const ResearchInventory & ri)
+auto CombatSimulator::createFAPVersion(StoredUnit u,const ResearchInventory & ri)
 {
     int armor_upgrades = ri.getUpLevel(u.type_.armorUpgrade()) + 2 * (u.type_ == UnitTypes::Zerg_Ultralisk * ri.getUpLevel(UpgradeTypes::Chitinous_Plating));
 
@@ -59,7 +59,7 @@ auto CombatSimulator::createFAPVersion(const StoredUnit u,const ResearchInventor
         ;
 }
 
-auto CombatSimulator::createModifiedFAPVersion(const StoredUnit u, const ResearchInventory &ri, const Position & chosen_pos, const UpgradeType &upgrade, const TechType &tech)
+auto CombatSimulator::createModifiedFAPVersion(StoredUnit u, const ResearchInventory &ri, const Position & chosen_pos, const UpgradeType &upgrade, const TechType &tech)
 {
     int armor_upgrades = ri.getUpLevel(u.type_.armorUpgrade()) +
         2 * (u.type_ == UnitTypes::Zerg_Ultralisk * ri.getUpLevel(UpgradeTypes::Chitinous_Plating)) +
@@ -92,7 +92,7 @@ auto CombatSimulator::createModifiedFAPVersion(const StoredUnit u, const Researc
     int units_inside_object = 2 + (u.type_ == UnitTypes::Protoss_Carrier) * (2 + 4 * ri.getUpLevel(UpgradeTypes::Carrier_Capacity)); // 2 if bunker, 4 if carrier, 8 if "carrier capacity" is present. // Needs to extend for every race. Needs to include an indicator for self.
 
     return FAP::makeUnit<StoredUnit*>()
-        .setData(this)
+        .setData(u)
         .setUnitType(u.type_)
         .setPosition(chosen_pos)
         .setHealth(u.health_)

--- a/CombatSimulator.cpp
+++ b/CombatSimulator.cpp
@@ -40,7 +40,7 @@ auto CombatSimulator::createFAPVersion(StoredUnit u,const ResearchInventory & ri
     int units_inside_object = 2 + (u.type_ == UnitTypes::Protoss_Carrier) * (2 + 4 * ri.getUpLevel(UpgradeTypes::Carrier_Capacity)); // 2 if bunker, 4 if carrier, 8 if "carrier capacity" is present.
 
     return FAP::makeUnit<StoredUnit*>()
-        .setData(u)
+        .setData(&u)
         .setUnitType(u.type_)
         .setPosition(u.pos_)
         .setHealth(u.health_)
@@ -92,7 +92,7 @@ auto CombatSimulator::createModifiedFAPVersion(StoredUnit u, const ResearchInven
     int units_inside_object = 2 + (u.type_ == UnitTypes::Protoss_Carrier) * (2 + 4 * ri.getUpLevel(UpgradeTypes::Carrier_Capacity)); // 2 if bunker, 4 if carrier, 8 if "carrier capacity" is present. // Needs to extend for every race. Needs to include an indicator for self.
 
     return FAP::makeUnit<StoredUnit*>()
-        .setData(u)
+        .setData(&u)
         .setUnitType(u.type_)
         .setPosition(chosen_pos)
         .setHealth(u.health_)
@@ -129,12 +129,12 @@ void CombatSimulator::runSimulation(int duration)
 
     // Update scores
     if (internalFAP_.getState().first && !internalFAP_.getState().first->empty())
-        friendly_fap_score_ = std::accumulate(internalFAP_.getState().first->begin(), internalFAP_.getState().first->end(), 0, [](int currentScore, auto FAPunit) { return static_cast<int>(currentScore + unitWeight(FAPunit)); });
+        friendly_fap_score_ = std::accumulate(internalFAP_.getState().first->begin(), internalFAP_.getState().first->end(), 0, [this](int currentScore, auto FAPunit) { return static_cast<int>(currentScore + unitWeight(FAPunit)); });
     else
         friendly_fap_score_ = 0;
 
     if (internalFAP_.getState().second && !internalFAP_.getState().second->empty())
-        enemy_fap_score_ = std::accumulate(internalFAP_.getState().second->begin(), internalFAP_.getState().second->end(), 0, [](int currentScore, auto FAPunit) { return static_cast<int>(currentScore + unitWeight(FAPunit)); });
+        enemy_fap_score_ = std::accumulate(internalFAP_.getState().second->begin(), internalFAP_.getState().second->end(), 0, [this](int currentScore, auto FAPunit) { return static_cast<int>(currentScore + unitWeight(FAPunit)); });
     else
         enemy_fap_score_ = 0;
 }
@@ -195,14 +195,14 @@ void CombatSimulator::addPlayersToMiniSimulation(const UpgradeType &upgrade, con
     }
 }
 
-const auto CombatSimulator::getFriendlySim()
+const std::vector<FAP::FAPUnit<StoredUnit*>> CombatSimulator::getFriendlySim()
 {
-    return internalFAP_.getState().first;
+    return *internalFAP_.getState().first;
 }
 
-const auto CombatSimulator::getEnemySim()
+const std::vector<FAP::FAPUnit<StoredUnit*>> CombatSimulator::getEnemySim()
 {
-    return internalFAP_.getState().second;
+    return *internalFAP_.getState().second;
 }
 
 int CombatSimulator::getFriendlyScore() const

--- a/CombatSimulator.cpp
+++ b/CombatSimulator.cpp
@@ -10,7 +10,7 @@ double CombatSimulator::unitWeight(FAP::FAPUnit<StoredUnit*> FAPunit)
     return  FAPunit.data->stock_value_ * static_cast<double>(FAPunit.health + FAPunit.shields) / static_cast<double>(FAPunit.maxHealth + FAPunit.maxShields);
 }
 
-auto CombatSimulator::createFAPVersion(StoredUnit u,const ResearchInventory & ri)
+auto CombatSimulator::createFAPVersion(StoredUnit &u,const ResearchInventory & ri)
 {
     int armor_upgrades = ri.getUpLevel(u.type_.armorUpgrade()) + 2 * (u.type_ == UnitTypes::Zerg_Ultralisk * ri.getUpLevel(UpgradeTypes::Chitinous_Plating));
 
@@ -59,7 +59,7 @@ auto CombatSimulator::createFAPVersion(StoredUnit u,const ResearchInventory & ri
         ;
 }
 
-auto CombatSimulator::createModifiedFAPVersion(StoredUnit u, const ResearchInventory &ri, const Position & chosen_pos, const UpgradeType &upgrade, const TechType &tech)
+auto CombatSimulator::createModifiedFAPVersion(StoredUnit &u, const ResearchInventory &ri, const Position & chosen_pos, const UpgradeType &upgrade, const TechType &tech)
 {
     int armor_upgrades = ri.getUpLevel(u.type_.armorUpgrade()) +
         2 * (u.type_ == UnitTypes::Zerg_Ultralisk * ri.getUpLevel(UpgradeTypes::Chitinous_Plating)) +
@@ -189,12 +189,12 @@ void CombatSimulator::addPlayersToMiniSimulation(const UpgradeType &upgrade, con
     }
 }
 
-const std::vector<FAP::FAPUnit<StoredUnit*>> CombatSimulator::getFriendlySim()
+std::vector<FAP::FAPUnit<StoredUnit*>> CombatSimulator::getFriendlySim()
 {
     return *internalFAP_.getState().first;
 }
 
-const std::vector<FAP::FAPUnit<StoredUnit*>> CombatSimulator::getEnemySim()
+std::vector<FAP::FAPUnit<StoredUnit*>> CombatSimulator::getEnemySim()
 {
     return *internalFAP_.getState().second;
 }

--- a/CombatSimulator.cpp
+++ b/CombatSimulator.cpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "Source/CombatSimulator.h"
 #include "Source/UnitInventory.h"
 #include <numeric>
@@ -57,7 +59,7 @@ auto CombatSimulator::createFAPVersion(const StoredUnit u,const ResearchInventor
         ;
 }
 
-auto CombatSimulator::createModifiedFAPVersion(const StoredUnit u, const ResearchInventory &ri, const Position & chosen_pos = Positions::Origin, const UpgradeType &upgrade = UpgradeTypes::None, const TechType &tech = TechTypes::None)
+auto CombatSimulator::createModifiedFAPVersion(const StoredUnit u, const ResearchInventory &ri, const Position & chosen_pos, const UpgradeType &upgrade, const TechType &tech)
 {
     int armor_upgrades = ri.getUpLevel(u.type_.armorUpgrade()) +
         2 * (u.type_ == UnitTypes::Zerg_Ultralisk * ri.getUpLevel(UpgradeTypes::Chitinous_Plating)) +
@@ -117,7 +119,7 @@ int CombatSimulator::getScoreGap(bool friendly) const
         return getEnemyScore() - getFriendlyScore();
 }
 
-void CombatSimulator::runSimulation(int duration = FAP_SIM_DURATION)
+void CombatSimulator::runSimulation(int duration)
 {
     // Run Sim
     if(duration)
@@ -162,7 +164,7 @@ Position CombatSimulator::positionMCFAP(const StoredUnit su)
 }
 
 
-void CombatSimulator::addExtraUnitToSimulation(StoredUnit u, bool friendly = true)
+void CombatSimulator::addExtraUnitToSimulation(StoredUnit u, bool friendly)
 {
     if(friendly)
         internalFAP_.addIfCombatUnitPlayer1(createFAPVersion(u, CUNYAIModule::friendly_player_model.researches_));
@@ -181,7 +183,7 @@ void CombatSimulator::addPlayersToSimulation()
 
 }
 
-void CombatSimulator::addPlayersToMiniSimulation(const UpgradeType &upgrade = UpgradeTypes::None, const TechType &tech = TechTypes::None)
+void CombatSimulator::addPlayersToMiniSimulation(const UpgradeType &upgrade, const TechType &tech)
 {
     for (auto &u : CUNYAIModule::friendly_player_model.units_.unit_map_) {
         Position pos = positionMiniFAP(true);

--- a/CombatSimulator.cpp
+++ b/CombatSimulator.cpp
@@ -139,13 +139,7 @@ void CombatSimulator::runSimulation(int duration)
         enemy_fap_score_ = 0;
 }
 
-bool CombatSimulator::unitDeadInFuture(const StoredUnit & unit, const int & number_of_frames_voted_death) const
-{
-    return unit.count_of_consecutive_predicted_deaths_ >= number_of_frames_voted_death;
-}
-
-
-Position CombatSimulator::positionMiniFAP(const bool friendly)
+Position CombatSimulator::createPositionMiniFAP(const bool friendly)
 {
     std::uniform_int_distribution<int> small_map(miniMap_ * friendly, miniMap_ + miniMap_ * friendly);     // default values for output.
     int rand_x = small_map(generator_);
@@ -155,7 +149,7 @@ Position CombatSimulator::positionMiniFAP(const bool friendly)
 
 
 
-Position CombatSimulator::positionMCFAP(const StoredUnit su)
+Position CombatSimulator::createPositionMCFAP(const StoredUnit su)
 {
     std::uniform_int_distribution<int> small_noise(static_cast<int>(-CUNYAIModule::getProperSpeed(su.type_)) * 4, static_cast<int>(CUNYAIModule::getProperSpeed(su.type_)) * 4);     // default values for output.
     int rand_x = small_noise(generator_);
@@ -186,11 +180,11 @@ void CombatSimulator::addPlayersToSimulation()
 void CombatSimulator::addPlayersToMiniSimulation(const UpgradeType &upgrade, const TechType &tech)
 {
     for (auto &u : CUNYAIModule::friendly_player_model.units_.unit_map_) {
-        Position pos = positionMiniFAP(true);
+        Position pos = createPositionMiniFAP(true);
         internalFAP_.addIfCombatUnitPlayer1(createModifiedFAPVersion(u.second, CUNYAIModule::friendly_player_model.researches_, pos, upgrade, tech));
     }
     for (auto &u : CUNYAIModule::enemy_player_model.units_.unit_map_) {
-        Position pos = positionMiniFAP(false);
+        Position pos = createPositionMiniFAP(false);
         internalFAP_.addIfCombatUnitPlayer2(createModifiedFAPVersion(u.second, CUNYAIModule::enemy_player_model.researches_, pos));
     }
 }

--- a/CombatSimulator.cpp
+++ b/CombatSimulator.cpp
@@ -1,4 +1,5 @@
-#include "Source\CombatSimulator.h"
+#include "Source/CombatSimulator.h"
+#include "Source/UnitInventory.h"
 #include <numeric>
 
 
@@ -108,6 +109,14 @@ auto CombatSimulator::createModifiedFAPVersion(const StoredUnit u, const Researc
         ;
 }
 
+int CombatSimulator::getScoreGap(bool friendly) const
+{
+    if (friendly)
+        return getFriendlyScore() - getEnemyScore();
+    else
+        return getEnemyScore() - getFriendlyScore();
+}
+
 void CombatSimulator::runSimulation(int duration = FAP_SIM_DURATION)
 {
     // Run Sim
@@ -194,12 +203,12 @@ const auto CombatSimulator::getEnemySim()
     return internalFAP_.getState().second;
 }
 
-int CombatSimulator::getFriendlyScore()
+int CombatSimulator::getFriendlyScore() const
 {
     return friendly_fap_score_;
 }
 
-int CombatSimulator::getEnemyScore()
+int CombatSimulator::getEnemyScore() const
 {
     return enemy_fap_score_;
 }

--- a/CombatSimulator.cpp
+++ b/CombatSimulator.cpp
@@ -1,0 +1,205 @@
+#include "Source\CombatSimulator.h"
+#include <numeric>
+
+
+double CombatSimulator::unitWeight(FAP::FAPUnit<StoredUnit*> FAPunit)
+{
+    return  FAPunit.data->stock_value_ * static_cast<double>(FAPunit.health + FAPunit.shields) / static_cast<double>(FAPunit.maxHealth + FAPunit.maxShields);
+}
+
+auto CombatSimulator::createFAPVersion(const StoredUnit u,const ResearchInventory & ri)
+{
+    int armor_upgrades = ri.getUpLevel(u.type_.armorUpgrade()) + 2 * (u.type_ == UnitTypes::Zerg_Ultralisk * ri.getUpLevel(UpgradeTypes::Chitinous_Plating));
+
+    int gun_upgrades = max(ri.getUpLevel(u.type_.groundWeapon().upgradeType()), ri.getUpLevel(u.type_.airWeapon().upgradeType()));
+    int shield_upgrades = static_cast<int>(u.shields_ > 0) * ri.getUpLevel(UpgradeTypes::Protoss_Plasma_Shields);
+
+    bool speed_tech = // safer to hardcode this.
+        (u.type_ == UnitTypes::Zerg_Zergling && ri.getUpLevel(UpgradeTypes::Metabolic_Boost)) ||
+        (u.type_ == UnitTypes::Zerg_Hydralisk && ri.getUpLevel(UpgradeTypes::Muscular_Augments)) ||
+        (u.type_ == UnitTypes::Zerg_Overlord && ri.getUpLevel(UpgradeTypes::Pneumatized_Carapace)) ||
+        (u.type_ == UnitTypes::Zerg_Ultralisk && ri.getUpLevel(UpgradeTypes::Anabolic_Synthesis)) ||
+        (u.type_ == UnitTypes::Protoss_Scout && ri.getUpLevel(UpgradeTypes::Gravitic_Thrusters)) ||
+        (u.type_ == UnitTypes::Protoss_Observer && ri.getUpLevel(UpgradeTypes::Gravitic_Boosters)) ||
+        (u.type_ == UnitTypes::Protoss_Zealot && ri.getUpLevel(UpgradeTypes::Leg_Enhancements)) ||
+        (u.type_ == UnitTypes::Terran_Vulture && ri.getUpLevel(UpgradeTypes::Ion_Thrusters));
+
+    bool range_upgrade = // safer to hardcode this.
+        (u.type_ == UnitTypes::Zerg_Hydralisk && ri.getUpLevel(UpgradeTypes::Grooved_Spines)) ||
+        (u.type_ == UnitTypes::Protoss_Dragoon && ri.getUpLevel(UpgradeTypes::Singularity_Charge)) ||
+        (u.type_ == UnitTypes::Terran_Marine && ri.getUpLevel(UpgradeTypes::U_238_Shells)) ||
+        (u.type_ == UnitTypes::Terran_Goliath && ri.getUpLevel(UpgradeTypes::Charon_Boosters)) ||
+        (u.type_ == UnitTypes::Terran_Barracks && ri.getUpLevel(UpgradeTypes::U_238_Shells));
+
+    bool attack_speed_upgrade =  // safer to hardcode this.
+        (u.type_ == UnitTypes::Zerg_Zergling && ri.getUpLevel(UpgradeTypes::Adrenal_Glands));
+
+    int units_inside_object = 2 + (u.type_ == UnitTypes::Protoss_Carrier) * (2 + 4 * ri.getUpLevel(UpgradeTypes::Carrier_Capacity)); // 2 if bunker, 4 if carrier, 8 if "carrier capacity" is present.
+
+    return FAP::makeUnit<StoredUnit*>()
+        .setData(u)
+        .setUnitType(u.type_)
+        .setPosition(u.pos_)
+        .setHealth(u.health_)
+        .setShields(u.shields_)
+        .setFlying(u.is_flying_)
+        .setElevation(u.elevation_)
+        .setAttackerCount(units_inside_object)
+        .setArmorUpgrades(armor_upgrades)
+        .setAttackUpgrades(gun_upgrades)
+        .setShieldUpgrades(shield_upgrades)
+        .setSpeedUpgrade(speed_tech)
+        .setAttackSpeedUpgrade(attack_speed_upgrade)
+        .setAttackCooldownRemaining(u.cd_remaining_)
+        .setStimmed(u.stimmed_)
+        .setRangeUpgrade(range_upgrade)
+        ;
+}
+
+auto CombatSimulator::createModifiedFAPVersion(const StoredUnit u, const ResearchInventory &ri, const Position & chosen_pos = Positions::Origin, const UpgradeType &upgrade = UpgradeTypes::None, const TechType &tech = TechTypes::None)
+{
+    int armor_upgrades = ri.getUpLevel(u.type_.armorUpgrade()) +
+        2 * (u.type_ == UnitTypes::Zerg_Ultralisk * ri.getUpLevel(UpgradeTypes::Chitinous_Plating)) +
+        (u.type_.armorUpgrade() == upgrade);
+
+    int gun_upgrades = max(ri.getUpLevel(u.type_.groundWeapon().upgradeType()) + u.type_.groundWeapon().upgradeType() == upgrade, ri.getUpLevel(u.type_.airWeapon().upgradeType()) + u.type_.airWeapon().upgradeType() == upgrade);
+
+    int shield_upgrades = static_cast<int>(u.shields_ > 0) * (ri.getUpLevel(UpgradeTypes::Protoss_Plasma_Shields) + UpgradeTypes::Protoss_Plasma_Shields == upgrade); // No tests here.
+
+    bool speed_tech = // safer to hardcode this.
+        (u.type_ == UnitTypes::Zerg_Zergling && (ri.getUpLevel(UpgradeTypes::Metabolic_Boost) || upgrade == UpgradeTypes::Metabolic_Boost)) ||
+        (u.type_ == UnitTypes::Zerg_Hydralisk && (ri.getUpLevel(UpgradeTypes::Muscular_Augments) || upgrade == UpgradeTypes::Muscular_Augments)) ||
+        (u.type_ == UnitTypes::Zerg_Overlord && (ri.getUpLevel(UpgradeTypes::Pneumatized_Carapace) || upgrade == UpgradeTypes::Pneumatized_Carapace)) ||
+        (u.type_ == UnitTypes::Zerg_Ultralisk && (ri.getUpLevel(UpgradeTypes::Anabolic_Synthesis) || upgrade == UpgradeTypes::Anabolic_Synthesis)) ||
+        (u.type_ == UnitTypes::Protoss_Scout && (ri.getUpLevel(UpgradeTypes::Gravitic_Thrusters) || upgrade == UpgradeTypes::Gravitic_Thrusters)) ||
+        (u.type_ == UnitTypes::Protoss_Observer && (ri.getUpLevel(UpgradeTypes::Gravitic_Boosters) || upgrade == UpgradeTypes::Gravitic_Boosters)) ||
+        (u.type_ == UnitTypes::Protoss_Zealot && (ri.getUpLevel(UpgradeTypes::Leg_Enhancements) || upgrade == UpgradeTypes::Leg_Enhancements)) ||
+        (u.type_ == UnitTypes::Terran_Vulture && (ri.getUpLevel(UpgradeTypes::Ion_Thrusters) || upgrade == UpgradeTypes::Ion_Thrusters));
+
+    bool range_upgrade = // safer to hardcode this.
+        (u.type_ == UnitTypes::Zerg_Hydralisk && (ri.getUpLevel(UpgradeTypes::Grooved_Spines) || upgrade == UpgradeTypes::Grooved_Spines)) ||
+        (u.type_ == UnitTypes::Protoss_Dragoon && (ri.getUpLevel(UpgradeTypes::Singularity_Charge) || upgrade == UpgradeTypes::Singularity_Charge)) ||
+        (u.type_ == UnitTypes::Terran_Marine && (ri.getUpLevel(UpgradeTypes::U_238_Shells) || upgrade == UpgradeTypes::U_238_Shells)) ||
+        (u.type_ == UnitTypes::Terran_Goliath && (ri.getUpLevel(UpgradeTypes::Charon_Boosters) || upgrade == UpgradeTypes::Charon_Boosters)) ||
+        (u.type_ == UnitTypes::Terran_Barracks && (ri.getUpLevel(UpgradeTypes::U_238_Shells) || upgrade == UpgradeTypes::U_238_Shells));
+
+    bool attack_speed_upgrade =  // safer to hardcode this.
+        (u.type_ == UnitTypes::Zerg_Zergling && (ri.getUpLevel(UpgradeTypes::Adrenal_Glands) || upgrade == UpgradeTypes::Adrenal_Glands));
+
+    int units_inside_object = 2 + (u.type_ == UnitTypes::Protoss_Carrier) * (2 + 4 * ri.getUpLevel(UpgradeTypes::Carrier_Capacity)); // 2 if bunker, 4 if carrier, 8 if "carrier capacity" is present. // Needs to extend for every race. Needs to include an indicator for self.
+
+    return FAP::makeUnit<StoredUnit*>()
+        .setData(this)
+        .setUnitType(u.type_)
+        .setPosition(chosen_pos)
+        .setHealth(u.health_)
+        .setShields(u.shields_)
+        .setFlying(u.is_flying_)
+        .setElevation(u.elevation_)
+        .setAttackerCount(units_inside_object)
+        .setArmorUpgrades(armor_upgrades)
+        .setAttackUpgrades(gun_upgrades)
+        .setShieldUpgrades(shield_upgrades)
+        .setSpeedUpgrade(speed_tech)
+        .setAttackSpeedUpgrade(attack_speed_upgrade)
+        .setAttackCooldownRemaining(u.cd_remaining_)
+        .setStimmed(u.stimmed_)
+        .setRangeUpgrade(range_upgrade)
+        ;
+}
+
+void CombatSimulator::runSimulation(int duration = FAP_SIM_DURATION)
+{
+    // Run Sim
+    if(duration)
+        internalFAP_.simulate(duration);
+    else
+        internalFAP_.simulate(FAP_SIM_DURATION);
+
+    // Update scores
+    if (internalFAP_.getState().first && !internalFAP_.getState().first->empty())
+        friendly_fap_score_ = std::accumulate(internalFAP_.getState().first->begin(), internalFAP_.getState().first->end(), 0, [](int currentScore, auto FAPunit) { return static_cast<int>(currentScore + unitWeight(FAPunit)); });
+    else
+        friendly_fap_score_ = 0;
+
+    if (internalFAP_.getState().second && !internalFAP_.getState().second->empty())
+        enemy_fap_score_ = std::accumulate(internalFAP_.getState().second->begin(), internalFAP_.getState().second->end(), 0, [](int currentScore, auto FAPunit) { return static_cast<int>(currentScore + unitWeight(FAPunit)); });
+    else
+        enemy_fap_score_ = 0;
+}
+
+bool CombatSimulator::unitDeadInFuture(const StoredUnit & unit, const int & number_of_frames_voted_death) const
+{
+    return unit.count_of_consecutive_predicted_deaths_ >= number_of_frames_voted_death;
+}
+
+
+Position CombatSimulator::positionMiniFAP(const bool friendly)
+{
+    std::uniform_int_distribution<int> small_map(miniMap_ * friendly, miniMap_ + miniMap_ * friendly);     // default values for output.
+    int rand_x = small_map(generator_);
+    int rand_y = small_map(generator_);
+    return Position(rand_x, rand_y);
+}
+
+
+
+Position CombatSimulator::positionMCFAP(const StoredUnit su)
+{
+    std::uniform_int_distribution<int> small_noise(static_cast<int>(-CUNYAIModule::getProperSpeed(su.type_)) * 4, static_cast<int>(CUNYAIModule::getProperSpeed(su.type_)) * 4);     // default values for output.
+    int rand_x = small_noise(generator_);
+    int rand_y = small_noise(generator_);
+    return Position(rand_x, rand_y) + su.pos_;
+}
+
+
+void CombatSimulator::addExtraUnitToSimulation(StoredUnit u, bool friendly = true)
+{
+    if(friendly)
+        internalFAP_.addIfCombatUnitPlayer1(createFAPVersion(u, CUNYAIModule::friendly_player_model.researches_));
+    else
+        internalFAP_.addIfCombatUnitPlayer1(createFAPVersion(u, CUNYAIModule::enemy_player_model.researches_));
+}
+
+void CombatSimulator::addPlayersToSimulation()
+{
+    for (auto &u : CUNYAIModule::friendly_player_model.units_.unit_map_) {
+        internalFAP_.addIfCombatUnitPlayer1(createFAPVersion(u.second, CUNYAIModule::friendly_player_model.researches_));
+    }
+    for (auto &u : CUNYAIModule::enemy_player_model.units_.unit_map_) {
+        internalFAP_.addIfCombatUnitPlayer2(createFAPVersion(u.second, CUNYAIModule::enemy_player_model.researches_));
+    }
+
+}
+
+void CombatSimulator::addPlayersToMiniSimulation(const UpgradeType &upgrade = UpgradeTypes::None, const TechType &tech = TechTypes::None)
+{
+    for (auto &u : CUNYAIModule::friendly_player_model.units_.unit_map_) {
+        Position pos = positionMiniFAP(true);
+        internalFAP_.addIfCombatUnitPlayer1(createModifiedFAPVersion(u.second, CUNYAIModule::friendly_player_model.researches_, pos, upgrade, tech));
+    }
+    for (auto &u : CUNYAIModule::enemy_player_model.units_.unit_map_) {
+        Position pos = positionMiniFAP(false);
+        internalFAP_.addIfCombatUnitPlayer2(createModifiedFAPVersion(u.second, CUNYAIModule::enemy_player_model.researches_, pos));
+    }
+}
+
+const auto CombatSimulator::getFriendlySim()
+{
+    return internalFAP_.getState().first;
+}
+
+const auto CombatSimulator::getEnemySim()
+{
+    return internalFAP_.getState().second;
+}
+
+int CombatSimulator::getFriendlyScore()
+{
+    return friendly_fap_score_;
+}
+
+int CombatSimulator::getEnemyScore()
+{
+    return enemy_fap_score_;
+}

--- a/Diagnostics.cpp
+++ b/Diagnostics.cpp
@@ -3,6 +3,7 @@
 #include "Source/Diagnostics.h"
 #include <BWAPI.h>
 #include "Source/CUNYAIModule.h"
+#include "Source/UnitInventory.h"
 #include <chrono>
 #include <map>
 

--- a/Diagnostics.cpp
+++ b/Diagnostics.cpp
@@ -644,7 +644,7 @@ void Diagnostics::onFrame()
     //Broodwar->drawTextScreen(500, 160, creep_colony_string);
 
     for (auto p = CUNYAIModule::land_inventory.ResourceInventory_.begin(); p != CUNYAIModule::land_inventory.ResourceInventory_.end() && !CUNYAIModule::land_inventory.ResourceInventory_.empty(); ++p) {
-        if (CUNYAIModule::isOnScreen(p->second.pos_, CUNYAIModule::currentMapInventory.screen_position_)) {
+        if (CUNYAIModule::isOnScreen(p->second.pos_, Broodwar->getScreenPosition())) {
             Broodwar->drawCircleMap(p->second.pos_, (p->second.type_.dimensionUp() + p->second.type_.dimensionLeft()) / 2, Colors::Cyan); // Plot their last known position.
             Broodwar->drawTextMap(p->second.pos_, "%d", p->second.current_stock_value_); // Plot their current value.
             Broodwar->drawTextMap(p->second.pos_.x, p->second.pos_.y + 10, "%d", p->second.number_of_miners_); // Plot their current value.
@@ -715,11 +715,11 @@ void Diagnostics::onFrame()
     //}
 
     for (auto & j : CUNYAIModule::friendly_player_model.units_.unit_map_) {
-        printPhase(j.second, CUNYAIModule::currentMapInventory.screen_position_);
+        printPhase(j.second, Broodwar->getScreenPosition());
     }
 
     //Diagnostic_Tiles(current_MapInventory.screen_position_, Colors::White);
-    drawDestination(CUNYAIModule::friendly_player_model.units_, CUNYAIModule::currentMapInventory.screen_position_, Colors::Grey);
+    drawDestination(CUNYAIModule::friendly_player_model.units_, Broodwar->getScreenPosition(), Colors::Grey);
 
     //Diagnostic_Watch_Expos();
     if (Broodwar->getFrameCount() % (24 * 60) == 0) {
@@ -727,23 +727,23 @@ void Diagnostics::onFrame()
         onFrameWritePlayerModel(CUNYAIModule::enemy_player_model);
     }
 
-    //drawTiles(CUNYAIModule::currentMapInventory.screen_position_);
+    //drawTiles(Broodwar->getScreenPosition());
     //for (auto e : CUNYAIModule::currentMapInventory.getExpoTilePositions())
-    //    drawCircle(Position(e), CUNYAIModule::currentMapInventory.screen_position_, 250);
+    //    drawCircle(Position(e), Broodwar->getScreenPosition(), 250);
 }
 
 void Diagnostics::drawAllVelocities(const UnitInventory ui)
 {
     for (auto u : ui.unit_map_) {
         Position destination = Position(u.second.pos_.x + u.second.velocity_x_ * 24, u.second.pos_.y + u.second.velocity_y_ * 24);
-        Diagnostics::drawLine(u.second.pos_, destination, CUNYAIModule::currentMapInventory.screen_position_, Colors::Green);
+        Diagnostics::drawLine(u.second.pos_, destination, Broodwar->getScreenPosition(), Colors::Green);
     }
 }
 
 void Diagnostics::drawAllHitPoints(const UnitInventory ui)
 {
     for (auto u : ui.unit_map_) {
-        Diagnostics::drawHitPoints(u.second, CUNYAIModule::currentMapInventory.screen_position_);
+        Diagnostics::drawHitPoints(u.second, Broodwar->getScreenPosition());
     }
 
 }
@@ -751,7 +751,7 @@ void Diagnostics::drawAllHitPoints(const UnitInventory ui)
 void Diagnostics::drawAllMAFAPaverages(const UnitInventory ui)
 {
     for (auto u : ui.unit_map_) {
-        Diagnostics::drawFAP(u.second, CUNYAIModule::currentMapInventory.screen_position_);
+        Diagnostics::drawFAP(u.second, Broodwar->getScreenPosition());
     }
 
 }
@@ -759,7 +759,7 @@ void Diagnostics::drawAllMAFAPaverages(const UnitInventory ui)
 void Diagnostics::drawAllFutureDeaths(const UnitInventory ui)
 {
     for (auto u : ui.unit_map_) {
-        Diagnostics::drawEstimatedDeath(u.second, CUNYAIModule::currentMapInventory.screen_position_);
+        Diagnostics::drawEstimatedDeath(u.second, Broodwar->getScreenPosition());
     }
 
 }
@@ -767,7 +767,7 @@ void Diagnostics::drawAllFutureDeaths(const UnitInventory ui)
 void Diagnostics::drawAllLastDamage(const UnitInventory ui)
 {
     for (auto u : ui.unit_map_) {
-        Diagnostics::drawLastDamage(u.second, CUNYAIModule::currentMapInventory.screen_position_);
+        Diagnostics::drawLastDamage(u.second, Broodwar->getScreenPosition());
     }
 
 }
@@ -776,7 +776,7 @@ void Diagnostics::drawAllLastDamage(const UnitInventory ui)
 void Diagnostics::drawAllSpamGuards(const UnitInventory ui)
 {
     for (auto u : ui.unit_map_) {
-        Diagnostics::drawSpamGuard(u.second, CUNYAIModule::currentMapInventory.screen_position_);
+        Diagnostics::drawSpamGuard(u.second, Broodwar->getScreenPosition());
     }
 }
 

--- a/Diagnostics.cpp
+++ b/Diagnostics.cpp
@@ -97,7 +97,7 @@ void Diagnostics::drawHitPoints(const StoredUnit unit, const Position &screen_po
 void Diagnostics::drawFAP(const StoredUnit unit, const Position &screen_pos) {
     if constexpr (DIAGNOSTIC_MODE) {
         Position upper_left = unit.pos_;
-        if (unit.valid_pos_ && CUNYAIModule::isOnScreen(upper_left, screen_pos) && unit.future_fap_value_ > 0) {
+        if (unit.valid_pos_ && CUNYAIModule::isOnScreen(upper_left, screen_pos) && CUNYAIModule::isFightingUnit(unit)) {
             // Draw the red background.
             upper_left.y = upper_left.y + unit.type_.dimensionUp();
             upper_left.x = upper_left.x - unit.type_.dimensionLeft();

--- a/LearningManager.cpp
+++ b/LearningManager.cpp
@@ -4,6 +4,7 @@
 # include "Source\LearningManager.h"
 # include "Source\Diagnostics.h"
 # include "Source\Build.h"
+# include "Source/UnitInventory.h"
 # include <fstream>
 # include <BWAPI.h>
 # include <cstdlib>

--- a/MapInventory.cpp
+++ b/MapInventory.cpp
@@ -77,19 +77,14 @@ void MapInventory::onStart()
 void MapInventory::onFrame()
 {
     //currentMapInventory.updateVision_Count();
-    updateScreen_Position();
     mainCurrentMap();
-    //createAirThreatField(enemy_player_model);
-    //createGroundThreatField(enemy_player_model);
+    setSafeBase();
     createDetectField(CUNYAIModule::enemy_player_model);
-    //currentMapInventory.createVisionField(enemy_player_model);
-    //currentMapInventory.createBlindField(enemy_player_model);
     createThreatField(CUNYAIModule::enemy_player_model);
     createThreatBufferField(CUNYAIModule::enemy_player_model);
     createExtraWideBufferField(CUNYAIModule::enemy_player_model);
     createOccupationField();
     createSurroundField(CUNYAIModule::enemy_player_model);
-    //DiagnosticSurroundTiles();
     DiagnosticThreatTiles();
 
 
@@ -162,11 +157,6 @@ double MapInventory::getLn_Supply_Ratio() const
 //    } // catch some odd case where you are dead anyway. Rather not crash.
 //    vision_tile_count_ = total_tiles;
 //}
-
-void MapInventory::updateScreen_Position()
-{
-    screen_position_ = Broodwar->getScreenPosition();
-}
 
 //In Tiles?
 void MapInventory::updateBuildablePos()
@@ -345,7 +335,7 @@ void MapInventory::updateMapVeins() {
 //    return map[startloc.x][startloc.y];
 //}
 
-int MapInventory::getFieldValue(const Position & pos, const vector<vector<int>>& field)
+int MapInventory::getFieldValue(const Position & pos, const vector<vector<int>>& field) const
 {
     TilePosition startloc = TilePosition(pos);
     return field[startloc.x][startloc.y];
@@ -989,7 +979,8 @@ Position MapInventory::getBaseWithMostSurvivors(const bool &friendly, const bool
     return strongest_base;
 }
 
-Position MapInventory::getBasePositionNearest(Position &p) {
+Position MapInventory::getBasePositionNearest(const Position &p) const
+{
     int shortest_path = INT_MAX;
     Position closest_base = Positions::Origin;
     for (auto b : CUNYAIModule::basemanager.getBases()) {
@@ -1001,7 +992,8 @@ Position MapInventory::getBasePositionNearest(Position &p) {
     return closest_base;
 }
 
-vector<TilePosition> MapInventory::getExpoTilePositions() {
+vector<TilePosition> MapInventory::getExpoTilePositions() const
+{
     std::vector<TilePosition> expo_positions;
     for (auto & area : BWEM::Map::Instance().Areas()) {
         for (auto & base : area.Bases()) {
@@ -1011,7 +1003,7 @@ vector<TilePosition> MapInventory::getExpoTilePositions() {
     return expo_positions;
 }
 
-vector<TilePosition> MapInventory::getInsideWallTilePositions() {
+vector<TilePosition> MapInventory::getInsideWallTilePositions()  const{
     std::vector<TilePosition> macroPositions;
     BWEB::Path distanceBetweenWallAndStart;
     distanceBetweenWallAndStart.createUnitPath(Position(BWEB::Walls::getClosestWall(Broodwar->self()->getStartLocation())->getCentroid()), Position(Broodwar->self()->getStartLocation()));
@@ -1081,19 +1073,6 @@ void MapInventory::mainCurrentMap() {
         front_line_base_ = suspected_friendly_base + Position(UnitTypes::Zerg_Hatchery.dimensionLeft(), UnitTypes::Zerg_Hatchery.dimensionUp());
     }
 
-    // Update Safe Base
-        //otherwise go to your safest base - the one with least deaths near it and most units.
-    Position suspected_safe_base = Positions::Origin;
-
-    suspected_safe_base = getBaseWithMostSurvivors(true, false);
-
-    if (suspected_safe_base.isValid() && suspected_safe_base != safe_base_ && suspected_safe_base != Positions::Origin) {
-        safe_base_ = suspected_safe_base + Position(UnitTypes::Zerg_Hatchery.dimensionLeft(), UnitTypes::Zerg_Hatchery.dimensionUp());
-    }
-    else {
-        safe_base_ = front_line_base_;
-    }
-
 }
 
 //void MapInventory::writeMap(const vector< vector<int> > &mapin, const WalkPosition &center)
@@ -1153,7 +1132,7 @@ void MapInventory::mainCurrentMap() {
 //}
 
 
-vector<int> MapInventory::getRadialDistances(const UnitInventory & ui, const bool combat_units)
+vector<int> MapInventory::getRadialDistances(const UnitInventory & ui, const bool combat_units) const
 {
     vector<int> return_vector;
 
@@ -1399,11 +1378,12 @@ void MapInventory::createSurroundField(PlayerModel & enemy_player)
 //    return pfVisible_[t.x][t.y];
 //}
 
-const int MapInventory::getDetectField(TilePosition & t) {
+const int MapInventory::getDetectField(const TilePosition & t) const
+{
     return pfDetectThreat_[t.x][t.y];
 }
 
-const int MapInventory::getOccupationField(TilePosition & t)
+const int MapInventory::getOccupationField(const TilePosition & t) const
 {
     return pfOccupation_[t.x][t.y];
 }
@@ -1413,17 +1393,17 @@ const int MapInventory::getOccupationField(TilePosition & t)
 //    return pfBlindness_[t.x][t.y];
 //}
 
-const bool MapInventory::isInBufferField(TilePosition & t)
+bool MapInventory::isInBufferField(const TilePosition & t) const
 {
     return pfThreatBuffer_[t.x][t.y] > 0.0;
 }
 
-const bool MapInventory::isInExtraWideBufferField(TilePosition & t)
+bool MapInventory::isInExtraWideBufferField(const TilePosition & t) const
 {
     return pfExtraWideBuffer_[t.x][t.y] > 0.0;
 }
 
-const bool MapInventory::isInSurroundField(TilePosition & t)
+bool MapInventory::isInSurroundField(const TilePosition & t) const
 {
     return pfSurroundSquare_[t.x][t.y];
 }
@@ -1433,11 +1413,12 @@ void MapInventory::setSurroundField(TilePosition & t, bool newVal)
     pfSurroundSquare_[t.x][t.y] = newVal;
 }
 
-void MapInventory::DiagnosticField(double pf[256][256]) {
+void MapInventory::DiagnosticField(const double pf[256][256])  const
+{
     if (DIAGNOSTIC_MODE) {
         for (int i = 0; i < 256; ++i) {
             for (int j = 0; j < 256; ++j) {
-                if (CUNYAIModule::isOnScreen(Position(TilePosition{ static_cast<int>(i), static_cast<int>(j) }), CUNYAIModule::currentMapInventory.screen_position_)) {
+                if (CUNYAIModule::isOnScreen(Position(TilePosition{ static_cast<int>(i), static_cast<int>(j) }), Broodwar->getScreenPosition())) {
                     if (pf[i][j] > 0) {
                         Broodwar->drawTextMap(Position(TilePosition{ static_cast<int>(i), static_cast<int>(j) }) + Position(16, 16), "%4.2f", pf[i][j]);
                     }
@@ -1447,11 +1428,12 @@ void MapInventory::DiagnosticField(double pf[256][256]) {
     }
 }
 
-void MapInventory::DiagnosticField(int pf[256][256]) {
+void MapInventory::DiagnosticField(const int pf[256][256])  const
+{
     if (DIAGNOSTIC_MODE) {
         for (int i = 0; i < 256; ++i) {
             for (int j = 0; j < 256; ++j) {
-                if (CUNYAIModule::isOnScreen(Position(TilePosition{ static_cast<int>(i), static_cast<int>(j) }), CUNYAIModule::currentMapInventory.screen_position_)) {
+                if (CUNYAIModule::isOnScreen(Position(TilePosition{ static_cast<int>(i), static_cast<int>(j) }), Broodwar->getScreenPosition())) {
                     if (pf[i][j] > 0) {
                         Broodwar->drawTextMap(getCenterTile(TilePosition{ static_cast<int>(i), static_cast<int>(j) }), "%d", pf[i][j]);
                     }
@@ -1461,11 +1443,12 @@ void MapInventory::DiagnosticField(int pf[256][256]) {
     }
 }
 
-void MapInventory::DiagnosticField(bool pf[256][256]) {
+void MapInventory::DiagnosticField(const bool pf[256][256])  const
+{
     if (DIAGNOSTIC_MODE) {
         for (int i = 0; i < 256; ++i) {
             for (int j = 0; j < 256; ++j) {
-                if (CUNYAIModule::isOnScreen(Position(TilePosition{ static_cast<int>(i), static_cast<int>(j) }), CUNYAIModule::currentMapInventory.screen_position_)) {
+                if (CUNYAIModule::isOnScreen(Position(TilePosition{ static_cast<int>(i), static_cast<int>(j) }), Broodwar->getScreenPosition())) {
                     if (pf[i][j]) {
                         Broodwar->drawTextMap(getCenterTile(TilePosition{ static_cast<int>(i), static_cast<int>(j) }), "X");
                     }
@@ -1475,12 +1458,13 @@ void MapInventory::DiagnosticField(bool pf[256][256]) {
     }
 }
 
-void MapInventory::DiagnosticTile() {
+void MapInventory::DiagnosticTile() const
+{
     if (DIAGNOSTIC_MODE) {
             //tile positions are 32x32, walkable checks 8x8 minitiles.
         for (auto i = 0; i < Broodwar->mapWidth(); ++i) {
             for (auto j = 0; j < Broodwar->mapHeight(); ++j) {
-                if (CUNYAIModule::isOnScreen(Position(TilePosition{ static_cast<int>(i), static_cast<int>(j) }), CUNYAIModule::currentMapInventory.screen_position_)) {
+                if (CUNYAIModule::isOnScreen(Position(TilePosition{ static_cast<int>(i), static_cast<int>(j) }), Broodwar->getScreenPosition())) {
                     Broodwar->drawTextMap(getCenterTile(TilePosition{ static_cast<int>(i), static_cast<int>(j) }), "%d, %d", TilePosition{ static_cast<int>(i), static_cast<int>(j) }.x, TilePosition{ static_cast<int>(i), static_cast<int>(j) }.y);
                 }
             }
@@ -1488,48 +1472,29 @@ void MapInventory::DiagnosticTile() {
     }
 }
 
-//void MapInventory::DiagnosticAirThreats()
-//{
-//    DiagnosticField(pfAirThreat_);
-//}
-//
-//void MapInventory::DiagnosticGroundThreats()
-//{
-//    DiagnosticField(pfGroundThreat_);
-//}
-//
-//void MapInventory::DiagnosticVisibleTiles()
-//{
-//    DiagnosticField(pfVisible_);
-//}
 
-void MapInventory::DiagnosticOccupiedTiles()
+void MapInventory::DiagnosticOccupiedTiles() const
 {
     DiagnosticField(pfOccupation_);
 }
 
-void MapInventory::DiagnosticDetectedTiles()
+void MapInventory::DiagnosticDetectedTiles() const
 {
     DiagnosticField(pfDetectThreat_);
 }
 
-//void MapInventory::DiagnosticBlindTiles()
-//{
-//    DiagnosticField(pfBlindness_);
-//}
-
-void MapInventory::DiagnosticThreatTiles()
+void MapInventory::DiagnosticThreatTiles() const
 {
     DiagnosticField(pfThreat_);
 }
 
-void MapInventory::DiagnosticSurroundTiles()
+void MapInventory::DiagnosticSurroundTiles() const
 {
     DiagnosticField(pfSurroundSquare_);
 }
 
 
-void MapInventory::DiagnosticExtraWideBufferTiles()
+void MapInventory::DiagnosticExtraWideBufferTiles() const
 {
     DiagnosticField(pfExtraWideBuffer_);
 }
@@ -1747,12 +1712,7 @@ bool MapInventory::isScoutingPosition(const Position &pos)  const
     return scouting_bases_.end() != find(scouting_bases_.begin(), scouting_bases_.end(), pos);
 }
 
-bool MapInventory::isMarchingPosition(const Position &pos)   const
-{
-    return static_cast<int>(BWEM::Map::Instance().GetNearestArea(TilePosition(pos))->Id()) == static_cast<int>(BWEM::Map::Instance().GetNearestArea(TilePosition(enemy_base_ground_))->Id());
-}
-
-Position MapInventory::getClosestInVector(vector<Position> &posVector)  const
+Position MapInventory::getClosestInVector(const vector<Position> &posVector)  const
 {
     Position pos_holder = Positions::Origin;
     int dist_holder = INT_MAX;
@@ -1765,7 +1725,7 @@ Position MapInventory::getClosestInVector(vector<Position> &posVector)  const
     return pos_holder;
 }
 
-Position MapInventory::getFurthestInVector(vector<Position> &posVector)   const
+Position MapInventory::getFurthestInVector(const vector<Position> &posVector)   const
 {
     Position pos_holder = Positions::Origin;
     int dist_holder = INT_MIN;
@@ -1854,12 +1814,12 @@ void MapInventory::assignLateScoutMovement(const Position closest_enemy) {
 //    return CUNYAIModule::currentMapInventory.pfVisible_[TilePosition(p).x][TilePosition(p).y] > 0;
 //}
 
-bool MapInventory::isTileThreatened(const TilePosition & tp)
+bool MapInventory::isTileThreatened(const TilePosition & tp) const
 {
     return CUNYAIModule::currentMapInventory.pfThreat_[tp.x][tp.y] > 0;
 }
 
-double MapInventory::getTileThreat(const TilePosition & tp)
+double MapInventory::getTileThreat(const TilePosition & tp) const
 {
     return CUNYAIModule::currentMapInventory.pfThreat_[tp.x][tp.y];
 }
@@ -1874,27 +1834,27 @@ int MapInventory::getExpoPositionScore(const Position & p)
 }
 
 
-Position MapInventory::getSafeBase()
+Position MapInventory::getSafeBase() const
 {
     return safe_base_;
 }
 
-Position MapInventory::getEnemyBaseGround()
+Position MapInventory::getEnemyBaseGround() const
 {
     return enemy_base_ground_;
 }
 
-Position MapInventory::getEnemyBaseAir()
+Position MapInventory::getEnemyBaseAir() const
 {
     return enemy_base_air_;
 }
 
-Position MapInventory::getFrontLineBase()
+Position MapInventory::getFrontLineBase() const
 {
     return front_line_base_;
 }
 
-vector<Position> MapInventory::getScoutingBases()
+vector<Position> MapInventory::getScoutingBases() const
 {
     return scouting_bases_;
 }
@@ -1903,3 +1863,17 @@ int MapInventory::getMyMapPortion() const
 {
     return CUNYAIModule::convertTileDistanceToPixelDistance(sqrt(pow(Broodwar->mapHeight(), 2) + pow(Broodwar->mapWidth(), 2)) / static_cast<double>(Broodwar->getStartLocations().size()));;
 }; 
+
+void MapInventory::setSafeBase() {
+    // Update Safe Base
+    Position suspected_safe_base = Positions::Origin;
+
+    suspected_safe_base = getBaseWithMostSurvivors(true, false);
+
+    if (suspected_safe_base.isValid() && suspected_safe_base != safe_base_ && suspected_safe_base != Positions::Origin) {
+        safe_base_ = suspected_safe_base + Position(UnitTypes::Zerg_Hatchery.dimensionLeft(), UnitTypes::Zerg_Hatchery.dimensionUp());
+    }
+    else {
+        safe_base_ = front_line_base_;
+    }
+}

--- a/MapInventory.cpp
+++ b/MapInventory.cpp
@@ -586,110 +586,110 @@ int MapInventory::getRadialDistanceOutFromHome(const Position A) const
 //}
 
 
-// This function causes several items to break. In particular, building locations will end up being inside the unwalkable area!
-void MapInventory::updateUnwalkableWithBuildings() {
-    int map_x = Broodwar->mapWidth() * 4;
-    int map_y = Broodwar->mapHeight() * 4; //tile positions are 32x32, walkable checks 8x8 minitiles.
-
-    unwalkable_barriers_with_buildings_ = unwalkable_barriers_;
-
-    //mark all occupied areas.  IAAUW
-
-    for (auto & u : CUNYAIModule::friendly_player_model.units_.unit_map_) {
-        if (u.second.type_.isBuilding()) {
-
-            // mark the building's current position.
-            int max_x = u.second.pos_.x + u.second.type_.dimensionLeft();
-            int min_x = u.second.pos_.x - u.second.type_.dimensionRight();
-            int max_y = u.second.pos_.y + u.second.type_.dimensionUp();
-            int min_y = u.second.pos_.y - u.second.type_.dimensionDown();
-
-            WalkPosition max_upper_left = WalkPosition(Position(min_x, min_y));
-            WalkPosition max_lower_right = WalkPosition(Position(max_x, max_y));
-
-            //respect map bounds please.
-            WalkPosition lower_right_modified = WalkPosition(max_lower_right.x < map_x ? max_lower_right.x : map_x - 1, max_lower_right.y < map_y ? max_lower_right.y : map_y - 1);
-            WalkPosition upper_left_modified = WalkPosition(max_upper_left.x > 0 ? max_upper_left.x : 1, max_upper_left.y > 0 ? max_upper_left.y : 1);
-
-            for (auto minitile_x = upper_left_modified.x; minitile_x <= lower_right_modified.x; ++minitile_x) {
-                for (auto minitile_y = upper_left_modified.y; minitile_y <= lower_right_modified.y; ++minitile_y) { // Check all possible walkable locations.
-                    unwalkable_barriers_with_buildings_[minitile_x][minitile_y] = 1;
-                }
-            }
-        }
-    }
-
-    for (auto & e : CUNYAIModule::enemy_player_model.units_.unit_map_) {
-        if (e.second.type_.isBuilding()) {
-
-            // mark the building's current position.
-            int max_x = e.second.pos_.x + e.second.type_.dimensionLeft();
-            int min_x = e.second.pos_.x - e.second.type_.dimensionRight();
-            int max_y = e.second.pos_.y + e.second.type_.dimensionUp();
-            int min_y = e.second.pos_.y - e.second.type_.dimensionDown();
-
-            WalkPosition max_upper_left = WalkPosition(Position(min_x, min_y));
-            WalkPosition max_lower_right = WalkPosition(Position(max_x, max_y));
-
-            //respect map bounds please.
-            WalkPosition lower_right_modified = WalkPosition(max_lower_right.x < map_x ? max_lower_right.x : map_x - 1, max_lower_right.y < map_y ? max_lower_right.y : map_y - 1);
-            WalkPosition upper_left_modified = WalkPosition(max_upper_left.x > 0 ? max_upper_left.x : 1, max_upper_left.y > 0 ? max_upper_left.y : 1);
-
-            for (auto minitile_x = upper_left_modified.x; minitile_x <= lower_right_modified.x; ++minitile_x) {
-                for (auto minitile_y = upper_left_modified.y; minitile_y <= lower_right_modified.y; ++minitile_y) { // Check all possible walkable locations.
-                    unwalkable_barriers_with_buildings_[minitile_x][minitile_y] = 1;
-                }
-            }
-        }
-    }
-
-    for (auto & n : CUNYAIModule::neutral_player_model.units_.unit_map_) {
-        if (n.second.type_.isBuilding()) {
-
-            // mark the building's current position.
-            int max_x = n.second.pos_.x + n.second.type_.dimensionLeft();
-            int min_x = n.second.pos_.x - n.second.type_.dimensionRight();
-            int max_y = n.second.pos_.y + n.second.type_.dimensionUp();
-            int min_y = n.second.pos_.y - n.second.type_.dimensionDown();
-
-            WalkPosition max_upper_left = WalkPosition(Position(min_x, min_y));
-            WalkPosition max_lower_right = WalkPosition(Position(max_x, max_y));
-
-            //respect map bounds please.
-            WalkPosition lower_right_modified = WalkPosition(max_lower_right.x < map_x ? max_lower_right.x : map_x - 1, max_lower_right.y < map_y ? max_lower_right.y : map_y - 1);
-            WalkPosition upper_left_modified = WalkPosition(max_upper_left.x > 0 ? max_upper_left.x : 1, max_upper_left.y > 0 ? max_upper_left.y : 1);
-
-            for (auto minitile_x = upper_left_modified.x; minitile_x <= lower_right_modified.x; ++minitile_x) {
-                for (auto minitile_y = upper_left_modified.y; minitile_y <= lower_right_modified.y; ++minitile_y) { // Check all possible walkable locations.
-                    unwalkable_barriers_with_buildings_[minitile_x][minitile_y] = 1;
-                }
-            }
-        }
-    }
-
-    for (auto & u : CUNYAIModule::land_inventory.ResourceInventory_) {
-        // mark the building's current position.
-        int max_x = u.second.pos_.x + u.second.type_.dimensionLeft();
-        int min_x = u.second.pos_.x - u.second.type_.dimensionRight();
-        int max_y = u.second.pos_.y + u.second.type_.dimensionUp();
-        int min_y = u.second.pos_.y - u.second.type_.dimensionDown();
-
-        WalkPosition max_upper_left = WalkPosition(Position(min_x, min_y));
-        WalkPosition max_lower_right = WalkPosition(Position(max_x, max_y));
-
-        //respect map bounds please.
-        WalkPosition lower_right_modified = WalkPosition(max_lower_right.x < map_x ? max_lower_right.x : map_x - 1, max_lower_right.y < map_y ? max_lower_right.y : map_y - 1);
-        WalkPosition upper_left_modified = WalkPosition(max_upper_left.x > 0 ? max_upper_left.x : 1, max_upper_left.y > 0 ? max_upper_left.y : 1);
-
-        for (auto minitile_x = upper_left_modified.x; minitile_x <= lower_right_modified.x; ++minitile_x) {
-            for (auto minitile_y = upper_left_modified.y; minitile_y <= lower_right_modified.y; ++minitile_y) { // Check all possible walkable locations.
-                unwalkable_barriers_with_buildings_[minitile_x][minitile_y] = 1;
-            }
-        }
-
-    }
-
-}
+//// This function causes several items to break. In particular, building locations will end up being inside the unwalkable area!
+//void MapInventory::updateUnwalkableWithBuildings() {
+//    int map_x = Broodwar->mapWidth() * 4;
+//    int map_y = Broodwar->mapHeight() * 4; //tile positions are 32x32, walkable checks 8x8 minitiles.
+//
+//    unwalkable_barriers_with_buildings_ = unwalkable_barriers_;
+//
+//    //mark all occupied areas.  IAAUW
+//
+//    for (auto & u : CUNYAIModule::friendly_player_model.units_.unit_map_) {
+//        if (u.second.type_.isBuilding()) {
+//
+//            // mark the building's current position.
+//            int max_x = u.second.pos_.x + u.second.type_.dimensionLeft();
+//            int min_x = u.second.pos_.x - u.second.type_.dimensionRight();
+//            int max_y = u.second.pos_.y + u.second.type_.dimensionUp();
+//            int min_y = u.second.pos_.y - u.second.type_.dimensionDown();
+//
+//            WalkPosition max_upper_left = WalkPosition(Position(min_x, min_y));
+//            WalkPosition max_lower_right = WalkPosition(Position(max_x, max_y));
+//
+//            //respect map bounds please.
+//            WalkPosition lower_right_modified = WalkPosition(max_lower_right.x < map_x ? max_lower_right.x : map_x - 1, max_lower_right.y < map_y ? max_lower_right.y : map_y - 1);
+//            WalkPosition upper_left_modified = WalkPosition(max_upper_left.x > 0 ? max_upper_left.x : 1, max_upper_left.y > 0 ? max_upper_left.y : 1);
+//
+//            for (auto minitile_x = upper_left_modified.x; minitile_x <= lower_right_modified.x; ++minitile_x) {
+//                for (auto minitile_y = upper_left_modified.y; minitile_y <= lower_right_modified.y; ++minitile_y) { // Check all possible walkable locations.
+//                    unwalkable_barriers_with_buildings_[minitile_x][minitile_y] = 1;
+//                }
+//            }
+//        }
+//    }
+//
+//    for (auto & e : CUNYAIModule::enemy_player_model.units_.unit_map_) {
+//        if (e.second.type_.isBuilding()) {
+//
+//            // mark the building's current position.
+//            int max_x = e.second.pos_.x + e.second.type_.dimensionLeft();
+//            int min_x = e.second.pos_.x - e.second.type_.dimensionRight();
+//            int max_y = e.second.pos_.y + e.second.type_.dimensionUp();
+//            int min_y = e.second.pos_.y - e.second.type_.dimensionDown();
+//
+//            WalkPosition max_upper_left = WalkPosition(Position(min_x, min_y));
+//            WalkPosition max_lower_right = WalkPosition(Position(max_x, max_y));
+//
+//            //respect map bounds please.
+//            WalkPosition lower_right_modified = WalkPosition(max_lower_right.x < map_x ? max_lower_right.x : map_x - 1, max_lower_right.y < map_y ? max_lower_right.y : map_y - 1);
+//            WalkPosition upper_left_modified = WalkPosition(max_upper_left.x > 0 ? max_upper_left.x : 1, max_upper_left.y > 0 ? max_upper_left.y : 1);
+//
+//            for (auto minitile_x = upper_left_modified.x; minitile_x <= lower_right_modified.x; ++minitile_x) {
+//                for (auto minitile_y = upper_left_modified.y; minitile_y <= lower_right_modified.y; ++minitile_y) { // Check all possible walkable locations.
+//                    unwalkable_barriers_with_buildings_[minitile_x][minitile_y] = 1;
+//                }
+//            }
+//        }
+//    }
+//
+//    for (auto & n : CUNYAIModule::neutral_player_model.units_.unit_map_) {
+//        if (n.second.type_.isBuilding()) {
+//
+//            // mark the building's current position.
+//            int max_x = n.second.pos_.x + n.second.type_.dimensionLeft();
+//            int min_x = n.second.pos_.x - n.second.type_.dimensionRight();
+//            int max_y = n.second.pos_.y + n.second.type_.dimensionUp();
+//            int min_y = n.second.pos_.y - n.second.type_.dimensionDown();
+//
+//            WalkPosition max_upper_left = WalkPosition(Position(min_x, min_y));
+//            WalkPosition max_lower_right = WalkPosition(Position(max_x, max_y));
+//
+//            //respect map bounds please.
+//            WalkPosition lower_right_modified = WalkPosition(max_lower_right.x < map_x ? max_lower_right.x : map_x - 1, max_lower_right.y < map_y ? max_lower_right.y : map_y - 1);
+//            WalkPosition upper_left_modified = WalkPosition(max_upper_left.x > 0 ? max_upper_left.x : 1, max_upper_left.y > 0 ? max_upper_left.y : 1);
+//
+//            for (auto minitile_x = upper_left_modified.x; minitile_x <= lower_right_modified.x; ++minitile_x) {
+//                for (auto minitile_y = upper_left_modified.y; minitile_y <= lower_right_modified.y; ++minitile_y) { // Check all possible walkable locations.
+//                    unwalkable_barriers_with_buildings_[minitile_x][minitile_y] = 1;
+//                }
+//            }
+//        }
+//    }
+//
+//    for (auto & u : CUNYAIModule::land_inventory.ResourceInventory_) {
+//        // mark the building's current position.
+//        int max_x = u.second.pos_.x + u.second.type_.dimensionLeft();
+//        int min_x = u.second.pos_.x - u.second.type_.dimensionRight();
+//        int max_y = u.second.pos_.y + u.second.type_.dimensionUp();
+//        int min_y = u.second.pos_.y - u.second.type_.dimensionDown();
+//
+//        WalkPosition max_upper_left = WalkPosition(Position(min_x, min_y));
+//        WalkPosition max_lower_right = WalkPosition(Position(max_x, max_y));
+//
+//        //respect map bounds please.
+//        WalkPosition lower_right_modified = WalkPosition(max_lower_right.x < map_x ? max_lower_right.x : map_x - 1, max_lower_right.y < map_y ? max_lower_right.y : map_y - 1);
+//        WalkPosition upper_left_modified = WalkPosition(max_upper_left.x > 0 ? max_upper_left.x : 1, max_upper_left.y > 0 ? max_upper_left.y : 1);
+//
+//        for (auto minitile_x = upper_left_modified.x; minitile_x <= lower_right_modified.x; ++minitile_x) {
+//            for (auto minitile_y = upper_left_modified.y; minitile_y <= lower_right_modified.y; ++minitile_y) { // Check all possible walkable locations.
+//                unwalkable_barriers_with_buildings_[minitile_x][minitile_y] = 1;
+//            }
+//        }
+//
+//    }
+//
+//}
 
 //void MapInventory::updateLiveMapVeins(const UnitInventory &ui, const UnitInventory &ei, const ResourceInventory &ri) { // in progress.
 //

--- a/MobilityManager.cpp
+++ b/MobilityManager.cpp
@@ -2,6 +2,7 @@
 
 # include "Source\Diagnostics.h"
 # include "Source\MobilityManager.h"
+# include "Source/UnitInventory.h"
 # include <random> // C++ base random is low quality.
 # include <numeric>
 # include <math.h>

--- a/MobilityManager.cpp
+++ b/MobilityManager.cpp
@@ -28,8 +28,8 @@ bool Mobility::simplePathing(const Position &e_pos, const StoredUnit::Phase phas
     if (caution)
         unit_->move(pos_ + attract_vector_ + escape(TilePosition(pos_ + attract_vector_)));
     if (unit_->move(pos_ + attract_vector_)) {
-        Diagnostics::drawLine(pos_, pos_ + attract_vector_, CUNYAIModule::currentMapInventory.screen_position_, Colors::White);//Run towards it.
-        Diagnostics::drawLine(pos_, e_pos, CUNYAIModule::currentMapInventory.screen_position_, Colors::Red);//Run around 
+        Diagnostics::drawLine(pos_, pos_ + attract_vector_, Broodwar->getScreenPosition(), Colors::White);//Run towards it.
+        Diagnostics::drawLine(pos_, e_pos, Broodwar->getScreenPosition(), Colors::Red);//Run around 
         return CUNYAIModule::updateUnitPhase(unit_, phase);
     }
     return false;
@@ -193,7 +193,7 @@ bool Mobility::Tactical_Logic(UnitInventory &ei, const UnitInventory &ui, const 
             else
                 unit_->attack(pos_ + getVectorToEnemyDestination(target) + getVectorToBeyondEnemy(target));
         }
-        Diagnostics::drawLine(pos_, target->getPosition(), CUNYAIModule::currentMapInventory.screen_position_, color);
+        Diagnostics::drawLine(pos_, target->getPosition(), Broodwar->getScreenPosition(), color);
         return CUNYAIModule::updateUnitPhase(unit_, StoredUnit::Phase::Attacking);
     }
 

--- a/PlayerModelManager.cpp
+++ b/PlayerModelManager.cpp
@@ -108,8 +108,8 @@ void PlayerModel::updateSelfOnFrame()
     //Update general weaknesses.
     bool seen_air = CUNYAIModule::enemy_player_model.units_.stock_fliers_ + CUNYAIModule::enemy_player_model.casualties_.stock_fliers_ > 0;
     bool possible_air = CUNYAIModule::enemy_player_model.estimated_unseen_flyers_ > 0;
-    if(CUNYAIModule::army_starved) u_have_active_air_problem_ = (bool)( (CUNYAIModule::assemblymanager.testActiveAirProblem(researches_, true) && (seen_air || possible_air)) || (CUNYAIModule::assemblymanager.testPotentialAirVunerability(researches_, false) && seen_air) );
-    if(CUNYAIModule::army_starved) e_has_air_vunerability_ = (bool)(CUNYAIModule::assemblymanager.testActiveAirProblem(researches_, false) || CUNYAIModule::assemblymanager.testPotentialAirVunerability(researches_, true));
+    if(CUNYAIModule::army_starved) u_have_active_air_problem_ = (bool)( (CUNYAIModule::assemblymanager.testActiveAirDefenseBest() && (seen_air || possible_air)) || (CUNYAIModule::assemblymanager.testAirAttackBest() && seen_air) );
+    if(CUNYAIModule::army_starved) e_has_air_vunerability_ = (bool)(CUNYAIModule::assemblymanager.testActiveAirDefenseBest(false) || CUNYAIModule::assemblymanager.testAirAttackBest(false));
 
     //Update map inventory
     //radial_distances_from_enemy_ground_ = CUNYAIModule::current_MapInventory.getRadialDistances(units_, true);

--- a/Research_Inventory.cpp
+++ b/Research_Inventory.cpp
@@ -239,3 +239,4 @@ int inferEarliestPossible(const UnitType & ut) {
 
     return build_time;
 };
+

--- a/ResourceInventory.cpp
+++ b/ResourceInventory.cpp
@@ -192,7 +192,7 @@ void ResourceInventory::updateMines() {
 void ResourceInventory::drawMineralRemaining() const
 {
     for (auto u : ResourceInventory_) {
-        Diagnostics::drawMineralsRemaining(u.second, CUNYAIModule::currentMapInventory.screen_position_);
+        Diagnostics::drawMineralsRemaining(u.second, Broodwar->getScreenPosition());
     }
 
 }

--- a/ResourceInventory.cpp
+++ b/ResourceInventory.cpp
@@ -197,22 +197,6 @@ void ResourceInventory::drawMineralRemaining() const
 
 }
 
-void ResourceInventory::drawUnreachablePatch(const MapInventory & inv) const
-{
-    if constexpr (DIAGNOSTIC_MODE) {
-        for (auto r = ResourceInventory_.begin(); r != ResourceInventory_.end() && !ResourceInventory_.empty(); r++) {
-            if (CUNYAIModule::isOnScreen(r->second.pos_, CUNYAIModule::currentMapInventory.screen_position_)) {
-                if (inv.unwalkable_barriers_with_buildings_[WalkPosition(r->second.pos_).x][WalkPosition(r->second.pos_).y] == 1) {
-                    Broodwar->drawCircleMap(r->second.pos_, (r->second.type_.dimensionUp() + r->second.type_.dimensionLeft()) / 2, Colors::Red, true); // Mark as RED if not in a walkable spot.
-                }
-                else if (inv.unwalkable_barriers_with_buildings_[WalkPosition(r->second.pos_).x][WalkPosition(r->second.pos_).y] == 0) {
-                    Broodwar->drawCircleMap(r->second.pos_, (r->second.type_.dimensionUp() + r->second.type_.dimensionLeft()) / 2, Colors::Blue, true); // Mark as blue if in a walkable spot.
-                }
-            }
-        }
-    }
-}
-
 int ResourceInventory::countLocalMiners()
 {
     return local_miners_;
@@ -237,6 +221,16 @@ int ResourceInventory::countLocalRefineries()
 {
     return local_refineries_;
 }
+
+void ResourceInventory::onFrame() {
+    if (Broodwar->getFrameCount() == 0) {
+        //update local resources
+        //current_MapInventory.updateMapVeinsOut(current_MapInventory.start_positions_[0], current_MapInventory.enemy_base_ground_, current_MapInventory.map_out_from_enemy_ground_);
+        ResourceInventory mineral_inventory = ResourceInventory(Broodwar->getStaticMinerals());
+        ResourceInventory geyser_inventory = ResourceInventory(Broodwar->getStaticGeysers());
+        *this = mineral_inventory + geyser_inventory; // for first initialization.
+    }
+};
 
 ResourceInventory operator+(const ResourceInventory& lhs, const ResourceInventory& rhs)
 {

--- a/Source/AssemblyManager.h
+++ b/Source/AssemblyManager.h
@@ -120,8 +120,8 @@ public:
 
     void setMaxUnit(const UnitType &ut, const int max); //Sets the maximum number of units to MAX.
 
-    static bool testActiveAirProblem(const ResearchInventory & ri, const bool & test_for_self_weakness);  // returns true if weak against air. Tests explosive damage.
-    static bool testPotentialAirVunerability(const ResearchInventory & ri, const bool & test_for_self_weakness); //Returns true if (players) units would do more damage if they flew. Player is self (if true) or to the enemy (if false). 
+    bool testActiveAirDefenseBest(const bool testSelfForWeakness = true) const; //Returns true if my units would do more damage if they only shot up. Plugging in false will consider if the enemy is better off with anti-air defenses.
+    bool testAirAttackBest(const bool testSelfForWeakness = true) const; //Returns true if my units would do more damage if they flew. Plugging in false will consider if the enemy is better off with air units.
 
     static void Print_Assembly_FAP_Cycle(const int & screen_x, const int & screen_y);     // print the assembly cycle we're thinking about.
 

--- a/Source/AssemblyManager.h
+++ b/Source/AssemblyManager.h
@@ -81,7 +81,7 @@ public:
     void updateOptimalCombatUnit(); // evaluates the optimal unit types from assembly_cycle_. Should be a LARGE comparison set, run this regularly but no more than once a frame to use moving averages instead of calculating each time a unit is made (high variance).
     static int returnUnitRank(const UnitType &ut);  //Simply returns the rank of a unit type in the buildfap sim. Higher rank = better!
     static bool checkBestUnit(const UnitType & ut); // returns true if preferred unit.
-    static void weightUnitSim(const bool & condition, const UnitType &unit, const double &weight); //Increases the weight of the unit in the sim by +weight (w can be negative to penalize), when conditions are met.
+    static void weightUnitSim(const bool & condition, const UnitType &unit, const int &weight); //Increases the weight of the unit in the sim by +weight (w can be negative to penalize), when conditions are met.
     static void applyWeightsFor(const UnitType &unit); //Checks all weightUnitSims relevant for unit.
     static void clearSimulationHistory(); // This should be ran when a unit is made/discovered so comparisons are fair!
 

--- a/Source/CUNYAIModule.h
+++ b/Source/CUNYAIModule.h
@@ -14,6 +14,7 @@
 #include "WorkerManager.h"
 #include "CombatManager.h"
 #include "BaseManager.h"
+#include "CombatSimulator.h"
 #include <bwem.h>
 #include "BWEB\BWEB.h"
 #include <functional>
@@ -21,7 +22,7 @@
 //#include "BrawlSim\BrawlSimLib\include\BrawlSim.hpp"
 #include <chrono> // for in-game frame clock.
 
-#define LARVA_BUILD_TIME 342
+#define LARVA_BUILD_TIME 342 // how long larva take to build
 
 constexpr bool RESIGN_MODE = false; // must be off for proper game close in SC-docker
 constexpr bool ANALYSIS_MODE = false; // Printing game logs, game status every few frames, etc.
@@ -304,8 +305,6 @@ public:
     bool checkSafeMineLoc(const Position pos, const UnitInventory &ui, const MapInventory &inv);
 
     static double bindBetween(double x, double lower_bound, double upper_bound);
-    // Gets total value of FAP structure using StoredUnits. If friendly player option is chose, it uses P1, the standard for friendly player.
-    static int getFAPScore(FAP::FastAPproximation<StoredUnit*>& fap, bool friendly_player);
     static bool checkMiniFAPForecast(UnitInventory & ui, UnitInventory & ei, const bool equality_is_win);
     // Tells if we will be dealing more damage than we recieve, proportionally or total.
     static bool checkSuperiorFAPForecast(const UnitInventory & ui, const UnitInventory & ei, const bool equality_is_win = false);

--- a/Source/CUNYAIModule.h
+++ b/Source/CUNYAIModule.h
@@ -96,7 +96,6 @@ public:
     static LearningManager learnedPlan;
     static WorkerManager workermanager;
     static BaseManager basemanager;
-    static CombatSimulator mainCombatSim;
 
     //These measure its clock.
     static int short_delay;

--- a/Source/CUNYAIModule.h
+++ b/Source/CUNYAIModule.h
@@ -23,8 +23,8 @@
 #define LARVA_BUILD_TIME 342 // how long larva take to build
 
 constexpr bool RESIGN_MODE = false; // must be off for proper game close in SC-docker
-constexpr bool ANALYSIS_MODE = false; // Printing game logs, game status every few frames, etc.
-constexpr bool DIAGNOSTIC_MODE = false; //Visualizations, printing records, etc. Should seperate these.
+constexpr bool ANALYSIS_MODE = true; // Printing game logs, game status every few frames, etc.
+constexpr bool DIAGNOSTIC_MODE = true; //Visualizations, printing records, etc. Should seperate these.
 constexpr bool MOVE_OUTPUT_BACK_TO_READ = false; // should be FALSE for sc-docker, TRUE for chaoslauncher at home & Training against base ai.
 constexpr bool TIT_FOR_TAT_ENGAGED = true; // permits in game-tit-for-tat responses.  Consider disabling this for TEST_MODE.
 constexpr bool RIP_REPLAY = false; // Copy replay information.
@@ -182,7 +182,7 @@ public:
     static int getChargableDistance(const Unit &u);
 
     //gets the nearest choke by simple counting along in the direction of the final unit.
-    static Position getNearestChoke(const Position & initial, const Position &final, const MapInventory & inv);
+    //static Position getNearestChoke(const Position & initial, const Position &final, const MapInventory & inv);
 
     //Strips the RACE_ from the front of the unit type string.
     static const char * noRaceName(const char *name);

--- a/Source/CUNYAIModule.h
+++ b/Source/CUNYAIModule.h
@@ -12,9 +12,9 @@
 #include "LearningManager.h"
 #include "TechManager.h"
 #include "WorkerManager.h"
+#include "CombatSimulator.h"
 #include "CombatManager.h"
 #include "BaseManager.h"
-#include "CombatSimulator.h"
 #include "BWEB\BWEB.h"
 #include <bwem.h>
 #include <functional>

--- a/Source/CUNYAIModule.h
+++ b/Source/CUNYAIModule.h
@@ -15,11 +15,9 @@
 #include "CombatManager.h"
 #include "BaseManager.h"
 #include "CombatSimulator.h"
-#include <bwem.h>
 #include "BWEB\BWEB.h"
+#include <bwem.h>
 #include <functional>
-
-//#include "BrawlSim\BrawlSimLib\include\BrawlSim.hpp"
 #include <chrono> // for in-game frame clock.
 
 #define LARVA_BUILD_TIME 342 // how long larva take to build
@@ -29,7 +27,6 @@ constexpr bool ANALYSIS_MODE = false; // Printing game logs, game status every f
 constexpr bool DIAGNOSTIC_MODE = false; //Visualizations, printing records, etc. Should seperate these.
 constexpr bool MOVE_OUTPUT_BACK_TO_READ = false; // should be FALSE for sc-docker, TRUE for chaoslauncher at home & Training against base ai.
 constexpr bool TIT_FOR_TAT_ENGAGED = true; // permits in game-tit-for-tat responses.  Consider disabling this for TEST_MODE.
-constexpr int FAP_SIM_DURATION = 24 * 5; // set FAP sim durations.
 constexpr bool RIP_REPLAY = false; // Copy replay information.
 constexpr bool PRINT_WD = false; // print a file to the current working directory.
 constexpr bool DISABLE_ATTACKING = false; // never attack - for exploring movement and reatreating.

--- a/Source/CUNYAIModule.h
+++ b/Source/CUNYAIModule.h
@@ -98,6 +98,7 @@ public:
     static LearningManager learnedPlan;
     static WorkerManager workermanager;
     static BaseManager basemanager;
+    static CombatSimulator mainCombatSim;
 
     //These measure its clock.
     static int short_delay;

--- a/Source/CUNYAIModule.h
+++ b/Source/CUNYAIModule.h
@@ -302,7 +302,6 @@ public:
     bool checkSafeMineLoc(const Position pos, const UnitInventory &ui, const MapInventory &inv);
 
     static double bindBetween(double x, double lower_bound, double upper_bound);
-    static bool checkMiniFAPForecast(UnitInventory & ui, UnitInventory & ei, const bool equality_is_win);
     // Tells if we will be dealing more damage than we recieve, proportionally or total.
     static bool checkSuperiorFAPForecast(const UnitInventory & ui, const UnitInventory & ei, const bool equality_is_win = false);
     // Tells the size of the surviving forces after a fight. The fodder setting also includes the results of surviving units that cannot defend themselves, such as a nexus.

--- a/Source/CombatManager.h
+++ b/Source/CombatManager.h
@@ -7,8 +7,6 @@
 #include "CombatSimulator.h"
 
 class CombatSimulator;
-class FastAPproximation;
-struct StoredUnit;
 
 class CombatManager {
 private:

--- a/Source/CombatManager.h
+++ b/Source/CombatManager.h
@@ -3,6 +3,7 @@
 #include "CUNYAIModule.h"
 #include "UnitInventory.h"
 #include <bwem.h>
+#include "FAP/FAP/include/FAP.hpp"
 
 class CombatManager {
 private:
@@ -39,7 +40,8 @@ public:
     static bool isCollectingForces(const UnitInventory &ui); //Checks if you're preparing to attack in a given UI. Tests the % of units pathing out.
     
     static bool isWorkerFight(const UnitInventory &friendly, const UnitInventory &enemy);      // Returns True if all enemy units are workers. 
-    //static bool isPulledWorkersFight(const UnitInventory &friendly, const UnitInventory &enemy);      // Returns True if all enemy units are Workers or Buildings
 
     int getSearchRadius(const Unit &u); //Returns the number of pixels we should search for targets.
+
+    void onFrame(); //Updates the combat sims so inferences can be drawn.
 };

--- a/Source/CombatManager.h
+++ b/Source/CombatManager.h
@@ -4,6 +4,11 @@
 #include "UnitInventory.h"
 #include <bwem.h>
 #include "FAP/FAP/include/FAP.hpp"
+#include "CombatSimulator.h"
+
+class CombatSimulator;
+class FastAPproximation;
+struct StoredUnit;
 
 class CombatManager {
 private:

--- a/Source/CombatSimulator.h
+++ b/Source/CombatSimulator.h
@@ -4,7 +4,7 @@
 #include "Source/FAP/FAP/include/FAP.hpp"
 #include "BWAPI.h"
 #include "Source/CUNYAIModule.h"
-#include "Source/UnitInventory.h"
+#include "UnitInventory.h"
 #include <random> // C++ base random is low quality.
 
 class CombatSimulator {
@@ -32,8 +32,9 @@ public:
     const auto getFriendlySim(); //Get the friendly sim - for looking only. Make sure you have Ran the sim before using.
     const auto getEnemySim(); //Get the enemy sim - for looking only. Make sure you have RAN the sim before using.
 
-    int getFriendlyScore(); //Returns the first player, the friendly player's score.
-    int getEnemyScore(); //Returns the second player, the enemy player's score. Duration is an optional number of frames.
+    int getFriendlyScore() const; //Returns the first player, the friendly player's score.
+    int getEnemyScore() const; //Returns the second player, the enemy player's score. Duration is an optional number of frames.
+    int getScoreGap(bool friendly = true) const;
     void runSimulation(int duration = FAP_SIM_DURATION); //runs simulation updates scores.
 
     bool unitDeadInFuture(const StoredUnit &unit, const int & number_of_frames_voted_death) const; // returns true if the unit has a MA forcast that implies it will be alive in X frames.

--- a/Source/CombatSimulator.h
+++ b/Source/CombatSimulator.h
@@ -1,11 +1,14 @@
 #pragma once
 // Class engages in several types of combat simulation. Serves as a wrapper between FAP and my existing inventories.
 // The first player should always be the "friendly" one. The second player will always be the hostile one.
-#include "Source/FAP/FAP/include/FAP.hpp"
+#include "FAP/FAP/include/FAP.hpp"
 #include "BWAPI.h"
-#include "Source/CUNYAIModule.h"
+#include "CUNYAIModule.h"
 #include "UnitInventory.h"
 #include <random> // C++ base random is low quality.
+
+struct StoredUnit;
+int FAP_SIM_DURATION;
 
 class CombatSimulator {
 

--- a/Source/CombatSimulator.h
+++ b/Source/CombatSimulator.h
@@ -1,0 +1,40 @@
+#pragma once
+// Class engages in several types of combat simulation. Serves as a wrapper between FAP and my existing inventories.
+// The first player should always be the "friendly" one. The second player will always be the hostile one.
+#include "Source/FAP/FAP/include/FAP.hpp"
+#include "BWAPI.h"
+#include "Source/CUNYAIModule.h"
+#include "Source/UnitInventory.h"
+#include <random> // C++ base random is low quality.
+
+class CombatSimulator {
+
+private:
+    std::default_random_engine generator_;  //Will be used to obtain a seed for the random number engine
+    static const int miniMap_ = 60; // SC Screen size is 680 X 240
+
+    FAP::FastAPproximation<StoredUnit*> internalFAP_; //Simulates the fight with some random perturbance.
+    int friendly_fap_score_;
+    int enemy_fap_score_;
+    double unitWeight(FAP::FAPUnit<StoredUnit*> FAPunit); //Grabs the value of a unit from the FAP object.
+
+    auto createFAPVersion(const StoredUnit u, const ResearchInventory & ri); // Returns a FAP stored Unit that has measured all details from the research inventory.
+    auto createModifiedFAPVersion(const StoredUnit u, const ResearchInventory &ri, const Position & chosen_pos = Positions::Origin, const UpgradeType &upgrade = UpgradeTypes::None, const TechType &tech = TechTypes::None); // creates a FAP object for the stored unit with new contents.
+
+    Position positionMiniFAP(const bool friendly);
+    Position positionMCFAP(const StoredUnit su);
+
+public:
+    void addExtraUnitToSimulation(StoredUnit u, bool friendly = true); // Squeeze in this extra unit into the sim as a counterfactual. Adjust if friendly or not.
+    void addPlayersToMiniSimulation(const UpgradeType &upgrade = UpgradeTypes::None, const TechType &tech = TechTypes::None); // Add both players into the simulation but give the friendly player some counterfactual technologies.
+    void addPlayersToSimulation(); //Add both friendly and enemy players to simulation as is.
+
+    const auto getFriendlySim(); //Get the friendly sim - for looking only. Make sure you have Ran the sim before using.
+    const auto getEnemySim(); //Get the enemy sim - for looking only. Make sure you have RAN the sim before using.
+
+    int getFriendlyScore(); //Returns the first player, the friendly player's score.
+    int getEnemyScore(); //Returns the second player, the enemy player's score. Duration is an optional number of frames.
+    void runSimulation(int duration = FAP_SIM_DURATION); //runs simulation updates scores.
+
+    bool unitDeadInFuture(const StoredUnit &unit, const int & number_of_frames_voted_death) const; // returns true if the unit has a MA forcast that implies it will be alive in X frames.
+};

--- a/Source/CombatSimulator.h
+++ b/Source/CombatSimulator.h
@@ -21,8 +21,8 @@ private:
     int enemy_fap_score_;
     double unitWeight(FAP::FAPUnit<StoredUnit*> FAPunit); //Grabs the value of a unit from the FAP object.
 
-    auto createFAPVersion(StoredUnit u, const ResearchInventory & ri); // Returns a FAP stored Unit that has measured all details from the research inventory.
-    auto createModifiedFAPVersion(StoredUnit u, const ResearchInventory &ri, const Position & chosen_pos = Positions::Origin, const UpgradeType &upgrade = UpgradeTypes::None, const TechType &tech = TechTypes::None); // creates a FAP object for the stored unit with new contents.
+    auto createFAPVersion(StoredUnit &u, const ResearchInventory &ri); // Returns a FAP stored Unit that has measured all details from the research inventory.
+    auto createModifiedFAPVersion(StoredUnit &u, const ResearchInventory &ri, const Position &chosen_pos = Positions::Origin, const UpgradeType &upgrade = UpgradeTypes::None, const TechType &tech = TechTypes::None); // creates a FAP object for the stored unit with new contents.
 
     Position createPositionMiniFAP(const bool friendly);
     Position createPositionMCFAP(const StoredUnit su);
@@ -32,8 +32,8 @@ public:
     void addPlayersToMiniSimulation(const UpgradeType &upgrade = UpgradeTypes::None, const TechType &tech = TechTypes::None); // Add both players into the simulation but give the friendly player some counterfactual technologies.
     void addPlayersToSimulation(); //Add both friendly and enemy players to simulation as is.
 
-    const std::vector<FAP::FAPUnit<StoredUnit*>> getFriendlySim(); //Get the friendly sim - for looking only. Make sure you have Ran the sim before using.
-    const std::vector<FAP::FAPUnit<StoredUnit*>> getEnemySim(); //Get the enemy sim - for looking only. Make sure you have RAN the sim before using.
+    std::vector<FAP::FAPUnit<StoredUnit*>> getFriendlySim(); //Get the friendly sim. Make sure you have Ran the sim before using. Careful, as it will your sim.
+    std::vector<FAP::FAPUnit<StoredUnit*>> getEnemySim(); //Get the enemy sim. Make sure you have RAN the sim before using.  Careful, as it will your sim.
 
     int getFriendlyScore() const; //Returns the first player, the friendly player's score.
     int getEnemyScore() const; //Returns the second player, the enemy player's score. Duration is an optional number of frames.

--- a/Source/CombatSimulator.h
+++ b/Source/CombatSimulator.h
@@ -32,8 +32,8 @@ public:
     void addPlayersToMiniSimulation(const UpgradeType &upgrade = UpgradeTypes::None, const TechType &tech = TechTypes::None); // Add both players into the simulation but give the friendly player some counterfactual technologies.
     void addPlayersToSimulation(); //Add both friendly and enemy players to simulation as is.
 
-    const auto getFriendlySim(); //Get the friendly sim - for looking only. Make sure you have Ran the sim before using.
-    const auto getEnemySim(); //Get the enemy sim - for looking only. Make sure you have RAN the sim before using.
+    const std::vector<FAP::FAPUnit<StoredUnit*>> getFriendlySim(); //Get the friendly sim - for looking only. Make sure you have Ran the sim before using.
+    const std::vector<FAP::FAPUnit<StoredUnit*>> getEnemySim(); //Get the enemy sim - for looking only. Make sure you have RAN the sim before using.
 
     int getFriendlyScore() const; //Returns the first player, the friendly player's score.
     int getEnemyScore() const; //Returns the second player, the enemy player's score. Duration is an optional number of frames.

--- a/Source/CombatSimulator.h
+++ b/Source/CombatSimulator.h
@@ -8,7 +8,7 @@
 #include <random> // C++ base random is low quality.
 
 struct StoredUnit;
-int FAP_SIM_DURATION;
+constexpr int FAP_SIM_DURATION = 24 * 5; // set FAP sim durations.
 
 class CombatSimulator {
 
@@ -21,8 +21,8 @@ private:
     int enemy_fap_score_;
     double unitWeight(FAP::FAPUnit<StoredUnit*> FAPunit); //Grabs the value of a unit from the FAP object.
 
-    auto createFAPVersion(const StoredUnit u, const ResearchInventory & ri); // Returns a FAP stored Unit that has measured all details from the research inventory.
-    auto createModifiedFAPVersion(const StoredUnit u, const ResearchInventory &ri, const Position & chosen_pos = Positions::Origin, const UpgradeType &upgrade = UpgradeTypes::None, const TechType &tech = TechTypes::None); // creates a FAP object for the stored unit with new contents.
+    auto createFAPVersion(StoredUnit u, const ResearchInventory & ri); // Returns a FAP stored Unit that has measured all details from the research inventory.
+    auto createModifiedFAPVersion(StoredUnit u, const ResearchInventory &ri, const Position & chosen_pos = Positions::Origin, const UpgradeType &upgrade = UpgradeTypes::None, const TechType &tech = TechTypes::None); // creates a FAP object for the stored unit with new contents.
 
     Position positionMiniFAP(const bool friendly);
     Position positionMCFAP(const StoredUnit su);

--- a/Source/CombatSimulator.h
+++ b/Source/CombatSimulator.h
@@ -24,8 +24,8 @@ private:
     auto createFAPVersion(StoredUnit u, const ResearchInventory & ri); // Returns a FAP stored Unit that has measured all details from the research inventory.
     auto createModifiedFAPVersion(StoredUnit u, const ResearchInventory &ri, const Position & chosen_pos = Positions::Origin, const UpgradeType &upgrade = UpgradeTypes::None, const TechType &tech = TechTypes::None); // creates a FAP object for the stored unit with new contents.
 
-    Position positionMiniFAP(const bool friendly);
-    Position positionMCFAP(const StoredUnit su);
+    Position createPositionMiniFAP(const bool friendly);
+    Position createPositionMCFAP(const StoredUnit su);
 
 public:
     void addExtraUnitToSimulation(StoredUnit u, bool friendly = true); // Squeeze in this extra unit into the sim as a counterfactual. Adjust if friendly or not.
@@ -39,6 +39,4 @@ public:
     int getEnemyScore() const; //Returns the second player, the enemy player's score. Duration is an optional number of frames.
     int getScoreGap(bool friendly = true) const;
     void runSimulation(int duration = FAP_SIM_DURATION); //runs simulation updates scores.
-
-    bool unitDeadInFuture(const StoredUnit &unit, const int & number_of_frames_voted_death) const; // returns true if the unit has a MA forcast that implies it will be alive in X frames.
 };

--- a/Source/Diagnostics.h
+++ b/Source/Diagnostics.h
@@ -111,6 +111,6 @@ public:
     {
         auto clockFinish = std::chrono::high_resolution_clock::now();
         auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(clockFinish - clockStart).count();
-        std::cout << "This clock " << p << " took " << duration << "ms." << std::endl;
+        if constexpr (DIAGNOSTIC_MODE) std::cout << "This clock " << p << " took " << duration << "ms." << std::endl;
     }
 };

--- a/Source/Diagnostics.h
+++ b/Source/Diagnostics.h
@@ -30,6 +30,7 @@ public:
     static void drawDestination(const UnitInventory & ui, const Position & screen_pos, Color col);
     static void drawDot(const Position & s_pos, const Position & screen_pos, Color col);
     static void drawCircle(const Position & s_pos, const Position & screen_pos, const int & radius, Color col);
+    static void drawBar(const Position & s_pos, const UnitType uType, const int barAmountComplete, const int barAmountFull, const Color colTop, const Color colUnder); //Draws a bar underneath unit. Note that if multiple bars are being drawn, there may be strange overlap, BW does not draw them all in the order expected.
     static void drawHitPoints(const StoredUnit unit, const Position & screen_pos);
     static void drawFAP(const StoredUnit unit, const Position & screen_pos);
     static void drawEstimatedDeath(const StoredUnit unit, const Position & screen_pos);
@@ -111,6 +112,7 @@ public:
     {
         auto clockFinish = std::chrono::high_resolution_clock::now();
         auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(clockFinish - clockStart).count();
-        if constexpr (DIAGNOSTIC_MODE) std::cout << "This clock " << p << " took " << duration << "ms." << std::endl;
+        if constexpr (DIAGNOSTIC_MODE)
+            if(duration >= 15) std::cout << "This clock " << p << " took " << duration << "ms." << std::endl;
     }
 };

--- a/Source/MapInventory.h
+++ b/Source/MapInventory.h
@@ -28,6 +28,7 @@ private:
     vector<Position> scouting_bases_;
     vector<Position> air_scouting_bases_;
 
+    int nScouts_ = 2; // How many scouts will we have? Set by fiat.
 
     bool discovered_enemy_this_frame_ = false;
     bool enemy_found_ = false;
@@ -65,6 +66,32 @@ private:
     double distanceTransformation(const int currentDistance) const; //returns 0.3 if 0 or 100/distacnce. Intended to be replaced by something smarter.
     double distanceTransformation(const double distanceFromTarget) const;  //returns 0.3 if 0 or 100/distacnce. Intended to be replaced by something smarter. Overload.
     
+    //Sets points you want to move your army towards on the map.
+    void assignArmyDestinations(); //Choses a ground location to move anti-ground towards.
+    void assignAirDestinations(); //Choses an air location to move AA towards.
+    void assignScoutDestinations(); //Choses positions at bases to scout.
+    void assignSafeBase(); //sets safe_base_ to base with "Most survivors" in a FAP sim.
+
+    void sendArmyTowardsPosition(const Position closest_enemy = Positions::Origin); //Sends anti-ground forces to postion. Has safety catches.
+    void sendAntiAirTowardsPosition(const Position closest_enemy = Positions::Origin); //Sends anti-ground forces to postion. Has safety catches.
+    void sendScoutTowardsPosition(const Position closest_enemy = Positions::Origin); //Sends scouts towards a position. Has safety catches.
+
+
+
+    //Potential field stuff. These potential fields are coomputationally quite lazy and only consider local maximums, they do not sum together properly.
+    void createDetectField(PlayerModel & enemy_player); //Marks all tiles that are pluasibly detected by enemy player.
+    void createOccupationField(); //Marks all the tiles you have occupied.
+    void createThreatBufferField(PlayerModel & enemy_player); // Must run after CreateThreatField
+    void createExtraWideBufferField(PlayerModel & enemy_player); // Must run after CreateThreatField, this is even wider than the threat buffer field.
+    void createThreatField(PlayerModel & enemy_player); // This marks all potentially threatened OR visible squares.
+    void createSurroundField(PlayerModel & enemy_player); //Must run after createThreatBuffer and CreatOccupationField
+
+    void updateGroundDangerousAreas();     //Marks Data for each area if it is "ground safe"
+    void updateBuildablePos();     // Updates the static locations of buildability on the map. Should only be called on game start. MiniTiles!
+    void updateUnwalkable();     // Updates the unwalkable portions of the map.
+    void updateMapVeins(); // Marks the distance from each obstacle. Requires updateunwalkablewithbuildings. 
+
+
     //Diagnostic Functions
     void DiagnosticField(const double pf[256][256]) const; //Diagnostic to show "potential fields"
     void DiagnosticField(const int pf[256][256]) const;  //Overload: Diagnostic to show "potential fields"
@@ -78,53 +105,15 @@ public:
     void onStart(); //Run this on game start.  Note game start does not actually have everything loaded - frame 0 is when the map is "ready" for most accessing.
     void onFrame(); //Run this every frame to update based on new information.
 
-    int nScouts = 2; // How many scouts will we have? Set by fiat.
-
-    //int expo_portion_of_the_map_;
-
-    //Marks Data for each area if it is "ground safe"
-    void updateGroundDangerousAreas();
-
-    // Updates the static locations of buildability on the map. Should only be called on game start. MiniTiles!
-    void updateBuildablePos();
-    // Updates the unwalkable portions of the map.
-    void updateUnwalkable();
-    // Updates unwalkable portions with existing blockades. Currently flawed.
-    //void MapInventory::updateUnwalkableWithBuildings();
-
-    // Marks and smooths the edges of the map. Dangerous- In progress.
-    void updateSmoothPos();
-    // Marks the distance from each obstacle. Requires updateunwalkablewithbuildings. //[Old usage:]Marks the main arteries of the map. 
-    void updateMapVeins();
-
-
     bool checkViableGroundPath(const Position A, const Position B) const;     // Is there a viable ground path? CPP, will not fail if thrown at a building.
-    bool isOnIsland(const Position A) const;  //Is this place pathable from home? Will not return error if your base IS the island.
 
     // Calls most of the map update functions when needed at a reduced and somewhat reasonable rate.
     void mainCurrentMap();
 
-    //Potential field stuff. These potential fields are coomputationally quite lazy and only consider local maximums, they do not sum together properly.
-    void createDetectField(PlayerModel & enemy_player); //Marks all tiles that are pluasibly detected by enemy player.
-    void createOccupationField(); //Marks all the tiles you have occupied.
-    void createThreatBufferField(PlayerModel & enemy_player); // Must run after CreateThreatField
-    void createExtraWideBufferField(PlayerModel & enemy_player); // Must run after CreateThreatField, this is even wider than the threat buffer field.
-    void createThreatField(PlayerModel & enemy_player); // This marks all potentially threatened OR visible squares.
-    void createSurroundField(PlayerModel & enemy_player); //Must run after createThreatBuffer and CreatOccupationField
-
     const int getDetectField(const TilePosition & t) const;
     const int getOccupationField(const TilePosition &t) const; // returns 1 for occupation by small units, 2 for larger units, and the sum for more.
 
-    void setSurroundField(TilePosition &t, bool newVal);
-
-    void assignArmyDestinations(); //Choses a ground location to move anti-ground towards.
-    void assignAirDestinations(); //Choses an air location to move AA towards.
-    void assignScoutDestinations(); //Choses positions at bases to scout.
-
-
-    bool isStartPosition(const Position & p)  const; //returns true if the position is a start position.
-
-
+    void setSurroundField(TilePosition &t, bool newVal); //Marks a position as occupied on the surround field.
 
     Position getEarlyGameScoutPosition() const;
     Position getEarlyGameArmyPosition() const;
@@ -135,37 +124,31 @@ public:
     Position getEnemyBaseAir() const; // Gets enemy air closest.
     Position getFrontLineBase() const; // Gets base I believe to be under threat.
     Position getBasePositionNearest(const Position &p) const;     //Which base position is most nearby this spot?
-    vector<int> getRadialDistances(const UnitInventory &ui, const bool combat_units) const;      // gets the radial distance of all units to the enemy base in pixels.
-    vector<Position> getScoutingBases() const;
+    Position getClosestInVector(const vector<Position>& posVector) const; // This command returns the closest position to my safe_base_.
+    Position getFurthestInVector(const vector<Position>& posVector) const; // This command returns the furthest position to my safe_base_.
+    int getMyMapPortion() const; // Gets the distance from spawn of the map that "belongs" to me, currently about 1/nth of the map where N is the number of bases.
     int getFieldValue(const Position & pos, const vector<vector<int>>& field) const;     // simply gets the value in FIELD at a particular POS.
     int getRadialDistanceOutFromEnemy(const Position A) const;     //Distance from enemy base in pixels, called a lot.
     int getRadialDistanceOutFromHome(const Position A) const;     //Distance from home in pixels, called a lot.
     int getDistanceBetween(const Position A, const Position B) const; // Simply gets the distance between two points using cpp, will not fail if a spot is inside a building.
+    int getExpoPositionScore(const Position &p); //Returns a score based on how good the expo appears to be.
     double getGasRatio() const;     // gets the (safe) log gas ratios, ln(gas)/(ln(min)+ln(gas))
     double getLn_Supply_Ratio() const; // gets the (safe) log of our supply total. Returns very high int instead of infinity.
-    int getMyMapPortion() const; // Gets the distance from spawn of the map that "belongs" to me, currently about 1/nth of the map where N is the number of bases.
     double getTileThreat(const TilePosition & tp) const; //Returns the amount of threat on the tile. 
-    Position getClosestInVector(const vector<Position>& posVector) const; // This command returns the closest position to my safe_base_.
-    Position getFurthestInVector(const vector<Position>& posVector) const; // This command returns the furthest position to my safe_base_.
     vector<TilePosition> getExpoTilePositions() const; //returns all possible expos and starting bases, found with BWEM.
     vector<TilePosition> getInsideWallTilePositions() const; //Returns the plausible macro hatch positions only.
-
+    vector<Position> getScoutingBases() const;
+    vector<int> getRadialDistances(const UnitInventory &ui, const bool combat_units) const;      // gets the radial distance of all units to the enemy base in pixels.
 
     bool isTileThreatened(const TilePosition & tp) const; //Returns true if the tile is under threat.
     bool isInBufferField(const TilePosition & t) const; //Returns true if the tile is in a buffer field.
     bool isInExtraWideBufferField(const TilePosition &t) const; //Returns true if the tile is in an EXTRA WIDE buffer field.
     bool isInSurroundField(const TilePosition &t) const; //Returns true if the tile is in a surround field.
+    bool isStartPosition(const Position & p)  const; //returns true if the position is a start position.
+    bool isOnIsland(const Position A) const;  //Is this place pathable from home? Will not return error if your base IS the island.
 
-    void assignLateArmyMovement(const Position closest_enemy);
-    void assignLateAirMovement(const Position closest_enemy);
-    void assignLateScoutMovement(const Position closest_enemy);
-
-    static int getExpoPositionScore(const Position &p);
-
-    void setSafeBase(); //sets safe_base_ to base with "Most survivors" in a FAP sim.
     bool checkExploredAllStartPositions(); //returns true if you have explored all start positions, false otherwise.
-
-
+    
     void DiagnosticOccupiedTiles() const;     //Draw some of the important stuff we have stored.
     void DiagnosticDetectedTiles() const;    //Draw some of the important stuff we have stored.
     void DiagnosticSurroundTiles() const;    //Draw some of the important stuff we have stored.

--- a/Source/MapInventory.h
+++ b/Source/MapInventory.h
@@ -28,6 +28,7 @@ private:
     vector<Position> scouting_bases_;
     vector<Position> air_scouting_bases_;
 
+
     bool discovered_enemy_this_frame_ = false;
     bool enemy_found_ = false;
     bool enemy_start_location_found_ = false;
@@ -49,9 +50,6 @@ private:
     bool pfSurroundSquare_[256][256] = { 0 }; //Is the square a viable square to move a unit to and improve the surround?
     void completeField(double pf[256][256], int reduction); //Creates a buffer around a field roughly REDUCTION units wide.
     void overfillField(double pfIn[256][256], double pfOut[256][256], int reduction); //Creates a buffer of an area SURROUNDING a field roughly REDUCTION units wide.
-    void DiagnosticField(double pf[256][256]); //Diagnostic to show "potential fields"
-    void DiagnosticField(int pf[256][256]);  //Overload: Diagnostic to show "potential fields"
-    void DiagnosticField(bool pf[256][256]); //Overload: Diagnostic to show "potential fields"
 
     // treatment order is as follows unwalkable->smoothed->veins->map veins from/to bases.
     vector< vector<bool> > buildable_positions_; // buildable = 1, otherwise 0.
@@ -59,6 +57,19 @@ private:
     vector< vector<int> > unwalkable_barriers_with_buildings_; // unwalkable = 1, otherwise 0.
     vector< vector<int> > smoothed_barriers_; // unwalkablity+buffer >= 1, otherwise 0. Totally cool idea but a trap. Base nothing off this.
     vector< vector<int> > map_veins_; //updates for building locations 1 if blocked, counts up around blocked squares if otherwise.
+
+    bool isScoutingPosition(const Position & pos) const;     //returns true if a position has been added to scoutpositions as determined by assignScoutDestionation.
+
+    Position getBaseWithMostSurvivors(const bool &friendly = true, const bool &fodder = true) const; // Returns the Position of the base with the most surviving units. Friendly is true (by default) to checking -yourself- for the strongest base. Fodder (T/F) is for the inclusion of fodder in that calculation.
+    
+    double distanceTransformation(const int currentDistance) const; //returns 0.3 if 0 or 100/distacnce. Intended to be replaced by something smarter.
+    double distanceTransformation(const double distanceFromTarget) const;  //returns 0.3 if 0 or 100/distacnce. Intended to be replaced by something smarter. Overload.
+    
+    //Diagnostic Functions
+    void DiagnosticField(const double pf[256][256]) const; //Diagnostic to show "potential fields"
+    void DiagnosticField(const int pf[256][256]) const;  //Overload: Diagnostic to show "potential fields"
+    void DiagnosticField(const bool pf[256][256]) const; //Overload: Diagnostic to show "potential fields"
+    void DiagnosticTile() const; //Draws a single tile, useful for other diagnostics.
 
 public:
     MapInventory();
@@ -68,142 +79,96 @@ public:
     void onFrame(); //Run this every frame to update based on new information.
 
     int nScouts = 2; // How many scouts will we have? Set by fiat.
-    Position screen_position_;
 
     //int expo_portion_of_the_map_;
 
     //Marks Data for each area if it is "ground safe"
     void updateGroundDangerousAreas();
-    vector<TilePosition> MapInventory::getExpoTilePositions(); //returns all possible expos and starting bases, found with BWEM.
-    vector<TilePosition> getInsideWallTilePositions(); //Returns the plausible macro hatch positions only.
-
-    // Updates our screen poisition. A little gratuitous but nevertheless useful.
-    void updateScreen_Position();
 
     // Updates the static locations of buildability on the map. Should only be called on game start. MiniTiles!
-    void MapInventory::updateBuildablePos();
+    void updateBuildablePos();
     // Updates the unwalkable portions of the map.
-    void MapInventory::updateUnwalkable();
+    void updateUnwalkable();
     // Updates unwalkable portions with existing blockades. Currently flawed.
     //void MapInventory::updateUnwalkableWithBuildings();
 
     // Marks and smooths the edges of the map. Dangerous- In progress.
-    void MapInventory::updateSmoothPos();
+    void updateSmoothPos();
     // Marks the distance from each obstacle. Requires updateunwalkablewithbuildings. //[Old usage:]Marks the main arteries of the map. 
-    void MapInventory::updateMapVeins();
+    void updateMapVeins();
 
-    // simply gets the value in FIELD at a particular POS.
-    static int getFieldValue(const Position & pos, const vector<vector<int>>& field);
 
-    //Distance from enemy base in pixels, called a lot.
-    int MapInventory::getRadialDistanceOutFromEnemy(const Position A) const; 
-    //Distance from home in pixels, called a lot.
-    int MapInventory::getRadialDistanceOutFromHome(const Position A) const; 
-    // Is there a viable ground path? CPP, will not fail if thrown at a building.
-    bool MapInventory::checkViableGroundPath(const Position A, const Position B) const;
-    //Is this place pathable from home? Will not return error if your base IS the island.
-    bool MapInventory::isOnIsland(const Position A) const; 
-
-    // gets the radial distance of all units to the enemy base in pixels.
-    vector<int> getRadialDistances(const UnitInventory &ui, const bool combat_units);  
-
-    // Returns the Position of the base with the most surviving units. Friendly is true (by default) to checking -yourself- for the strongest base. Fodder (T/F) is for the inclusion of fodder in that calculation.
-    Position MapInventory::getBaseWithMostSurvivors(const bool &friendly = true, const bool &fodder = true) const;
-    //Which base position is most nearby this spot?
-    Position getBasePositionNearest(Position &p); 
-
-    // write one of the map objects have created, centered around the passed position.
-    //void MapInventory::writeMap(const vector< vector<int> > &mapin, const WalkPosition &center); 
-    // read one of the map objects we have created, centered around the passed position.
-    //void MapInventory::readMap(vector< vector<int> > &mapin, const WalkPosition &center);
-
-    //returns true if you have explored all start positions, false otherwise.
-    bool checkExploredAllStartPositions(); 
+    bool checkViableGroundPath(const Position A, const Position B) const;     // Is there a viable ground path? CPP, will not fail if thrown at a building.
+    bool isOnIsland(const Position A) const;  //Is this place pathable from home? Will not return error if your base IS the island.
 
     // Calls most of the map update functions when needed at a reduced and somewhat reasonable rate.
     void mainCurrentMap();
 
     //Potential field stuff. These potential fields are coomputationally quite lazy and only consider local maximums, they do not sum together properly.
-    //void createAirThreatField(PlayerModel & enemy_player);
-    void createDetectField(PlayerModel & enemy_player);
-    //void createGroundThreatField(PlayerModel & enemy_player);
-    //void createVisionField(PlayerModel & enemy_player);
+    void createDetectField(PlayerModel & enemy_player); //Marks all tiles that are pluasibly detected by enemy player.
     void createOccupationField(); //Marks all the tiles you have occupied.
     void createThreatBufferField(PlayerModel & enemy_player); // Must run after CreateThreatField
     void createExtraWideBufferField(PlayerModel & enemy_player); // Must run after CreateThreatField, this is even wider than the threat buffer field.
-    //void createBlindField(PlayerModel & enemy_player); //Must run after createVisionField
     void createThreatField(PlayerModel & enemy_player); // This marks all potentially threatened OR visible squares.
     void createSurroundField(PlayerModel & enemy_player); //Must run after createThreatBuffer and CreatOccupationField
 
-    const int getDetectField(TilePosition & t);
-    //const double getAirThreatField(TilePosition &t);
-    //const double getGroundThreatField(TilePosition &t);
-    //const double getVisionField(TilePosition &t);
-    const int getOccupationField(TilePosition &t); // returns 1 for occupation by small units, 2 for larger units, and the sum for more.
-    const bool isInBufferField(TilePosition & t);
-    const bool isInExtraWideBufferField(TilePosition &t);
-    //const double getBlindField(TilePosition &t);
-    const bool isInSurroundField(TilePosition &t);
+    const int getDetectField(const TilePosition & t) const;
+    const int getOccupationField(const TilePosition &t) const; // returns 1 for occupation by small units, 2 for larger units, and the sum for more.
+
     void setSurroundField(TilePosition &t, bool newVal);
 
-    void DiagnosticTile();
-    //void DiagnosticAirThreats();
-    //void DiagnosticGroundThreats();
-    //void DiagnosticVisibleTiles();
-    void DiagnosticOccupiedTiles();
-    void DiagnosticDetectedTiles();
-    //void DiagnosticBlindTiles();
-    void DiagnosticSurroundTiles();
-    void DiagnosticThreatTiles();
-    void DiagnosticExtraWideBufferTiles();
+    void assignArmyDestinations(); //Choses a ground location to move anti-ground towards.
+    void assignAirDestinations(); //Choses an air location to move AA towards.
+    void assignScoutDestinations(); //Choses positions at bases to scout.
 
-    //void updateScoutLocations(const int &nScouts ); //Updates all visible scout locations. Chooses them if they DNE.
-    //Position MapInventory::createStartScoutLocation(); //Creates 1 scout position at time 0 for overlords. Selects from start positions only. Returns origin if fails.
-    //Position getStartEnemyLocation(); // gets an enemy start location that hasn't been explored. Will not move it if I am already marching towards it.
-    //bool isScoutingOrMarchingOnPosition(const Position & pos, const bool & explored_sufficient = false, const bool &check_marching = true);
-    void assignArmyDestinations();
-    void assignScoutDestinations();
-    void assignAirDestinations();
-    //returns true if a position is being scouted or marched towards. checks for area ID matchs.
-    bool isScoutingPosition(const Position & pos) const;
-    bool isMarchingPosition(const Position & pos) const;
-    Position getClosestInVector(vector<Position>& posVector) const; // This command returns the closest position to my safe_base_.
-    Position getFurthestInVector(vector<Position>& posVector) const; // This command returns the furthest position to my safe_base_.
+
     bool isStartPosition(const Position & p)  const; //returns true if the position is a start position.
-    double distanceTransformation(const int currentDistance) const; //returns 0.3 if 0 or 100/distacnce. Intended to be replaced by something smarter.
-    double distanceTransformation(const double distanceFromTarget) const;  //returns 0.3 if 0 or 100/distacnce. Intended to be replaced by something smarter. Overload.
-    void assignLateArmyMovement(const Position closest_enemy);
-    void assignLateAirMovement(const Position closest_enemy);
-    void assignLateScoutMovement(const Position closest_enemy);
+
+
 
     Position getEarlyGameScoutPosition() const;
     Position getEarlyGameArmyPosition() const;
     Position getEarlyGameAirPosition() const;
     Position getDistanceWeightedPosition(const Position & target_pos ) const; //Returns a position that is 1) not visible, 2) not already being scouted 3) randomly chosen based on a weighted distance from target_pos. Uses CPP and will consider walled-off positions. Will return origin if fails.
-    
+    Position getSafeBase() const; 
+    Position getEnemyBaseGround() const;
+    Position getEnemyBaseAir() const; // Gets enemy air closest.
+    Position getFrontLineBase() const; // Gets base I believe to be under threat.
+    Position getBasePositionNearest(const Position &p) const;     //Which base position is most nearby this spot?
+    vector<int> getRadialDistances(const UnitInventory &ui, const bool combat_units) const;      // gets the radial distance of all units to the enemy base in pixels.
+    vector<Position> getScoutingBases() const;
+    int getFieldValue(const Position & pos, const vector<vector<int>>& field) const;     // simply gets the value in FIELD at a particular POS.
+    int getRadialDistanceOutFromEnemy(const Position A) const;     //Distance from enemy base in pixels, called a lot.
+    int getRadialDistanceOutFromHome(const Position A) const;     //Distance from home in pixels, called a lot.
     int getDistanceBetween(const Position A, const Position B) const; // Simply gets the distance between two points using cpp, will not fail if a spot is inside a building.
-
     double getGasRatio() const;     // gets the (safe) log gas ratios, ln(gas)/(ln(min)+ln(gas))
     double getLn_Supply_Ratio() const; // gets the (safe) log of our supply total. Returns very high int instead of infinity.
     int getMyMapPortion() const; // Gets the distance from spawn of the map that "belongs" to me, currently about 1/nth of the map where N is the number of bases.
+    double getTileThreat(const TilePosition & tp) const; //Returns the amount of threat on the tile. 
+    Position getClosestInVector(const vector<Position>& posVector) const; // This command returns the closest position to my safe_base_.
+    Position getFurthestInVector(const vector<Position>& posVector) const; // This command returns the furthest position to my safe_base_.
+    vector<TilePosition> getExpoTilePositions() const; //returns all possible expos and starting bases, found with BWEM.
+    vector<TilePosition> getInsideWallTilePositions() const; //Returns the plausible macro hatch positions only.
 
-    //static bool isTileDetected(const Position &p); //Checks if a tile is detected by an enemy. Inaccurate.
-    //static bool isTileAirThreatened(const Position &p); //Checks if a tile is detected by an enemy. Inaccurate.
-    //static bool isTileGroundThreatened(const Position &p);
-    //static bool isTileVisible(const Position & p); // Checks if a tile is visible. Inaccurate. Prefer Blindness.
-    //static bool isTileBlind(const Position & p); // Checks if a tile is blind for an opponent. Inaccurate.
-    //Checks if a tile is detected by an enemy. Inaccurate.
 
-    static bool isTileThreatened(const TilePosition & tp);
+    bool isTileThreatened(const TilePosition & tp) const; //Returns true if the tile is under threat.
+    bool isInBufferField(const TilePosition & t) const; //Returns true if the tile is in a buffer field.
+    bool isInExtraWideBufferField(const TilePosition &t) const; //Returns true if the tile is in an EXTRA WIDE buffer field.
+    bool isInSurroundField(const TilePosition &t) const; //Returns true if the tile is in a surround field.
 
-    double getTileThreat(const TilePosition & tp);
+    void assignLateArmyMovement(const Position closest_enemy);
+    void assignLateAirMovement(const Position closest_enemy);
+    void assignLateScoutMovement(const Position closest_enemy);
 
     static int getExpoPositionScore(const Position &p);
 
-    Position getSafeBase();
-    Position getEnemyBaseGround();
-    Position getEnemyBaseAir();
-    Position getFrontLineBase();
-    vector<Position> getScoutingBases();
+    void setSafeBase(); //sets safe_base_ to base with "Most survivors" in a FAP sim.
+    bool checkExploredAllStartPositions(); //returns true if you have explored all start positions, false otherwise.
 
+
+    void DiagnosticOccupiedTiles() const;     //Draw some of the important stuff we have stored.
+    void DiagnosticDetectedTiles() const;    //Draw some of the important stuff we have stored.
+    void DiagnosticSurroundTiles() const;    //Draw some of the important stuff we have stored.
+    void DiagnosticThreatTiles() const;    //Draw some of the important stuff we have stored.
+    void DiagnosticExtraWideBufferTiles() const;    //Draw some of the important stuff we have stored.
 };

--- a/Source/ResourceInventory.h
+++ b/Source/ResourceInventory.h
@@ -50,6 +50,8 @@ public:
     ResourceInventory(); // for blank construction.
     ResourceInventory(const Unitset &unit_set);
 
+    void onFrame(); //Run this on frame. Technically only updates on frame 0, but could be updated again.
+
     std::map <Unit, Stored_Resource> ResourceInventory_;
 
     void addStored_Resource(Unit unit);     // Updates the count of resource units.
@@ -62,7 +64,6 @@ public:
     void updateResourceInventory(UnitInventory & ui, UnitInventory & ei, MapInventory &inv); // updates values of units in mine.
     void updateMines(); //counts number of viable gas mines and local mineral patches.
     void drawMineralRemaining() const;
-    void drawUnreachablePatch(const MapInventory & inv) const;;
     friend ResourceInventory operator + (const ResourceInventory & lhs, const ResourceInventory& rhs);
     friend ResourceInventory operator - (const ResourceInventory & lhs, const ResourceInventory & rhs);
 

--- a/Source/TechManager.h
+++ b/Source/TechManager.h
@@ -2,6 +2,7 @@
 #include "CUNYAIModule.h"
 #include "PlayerModelManager.h"
 #include "FAP\FAP\include\FAP.hpp" // could add to include path but this is more explicit.
+#include "CombatSimulator.h"
 
 using namespace BWAPI;
 

--- a/Source/UnitInventory.h
+++ b/Source/UnitInventory.h
@@ -235,7 +235,7 @@ struct UnitInventory {
     UnitInventory getBuildingInventory() const;
 
 
-    void updatePredictedStatus(bool friendly = true); // updates UI with FAP forecasts. Throws exceptions if something is misaligned.
+    void updateWithPredictedStatus(CombatSimulator sim, bool friendly = true); // updates UI with FAP forecasts. Throws exceptions if something is misaligned.
 
     //Gets a pointer to a stored unit when provided the unit pointer.
     StoredUnit* getStoredUnit(const Unit & u);

--- a/Source/UnitInventory.h
+++ b/Source/UnitInventory.h
@@ -9,6 +9,7 @@
 #include "FAP\FAP\include\FAP.hpp"
 #include "CombatSimulator.h"
 #include <random> // C++ base random is low quality.
+#include <vector>
 
 using namespace std;
 using namespace BWAPI;
@@ -16,6 +17,7 @@ using namespace BWAPI;
 // Two dependent structures for this inventory manager, a container of enemy_units and enemy units itself. Intend to add more funtionality to Enemy_Inventory, such as upgrades, etc.  May revisit when I learn about parentage, but ought to function for now.
 class MapInventory;
 class Reservation;
+class CombatSimulator;
 
 struct StoredUnit {
 
@@ -233,7 +235,7 @@ struct UnitInventory {
     UnitInventory getBuildingInventory() const;
 
 
-    void updatePredictedStatus(CombatSimulator cs); // updates UI with FAP forecasts. Throws exceptions if something is misaligned.
+    void updatePredictedStatus(const CombatSimulator cs); // updates UI with FAP forecasts. Throws exceptions if something is misaligned.
 
     //Gets a pointer to a stored unit when provided the unit pointer.
     StoredUnit* getStoredUnit(const Unit & u);

--- a/Source/UnitInventory.h
+++ b/Source/UnitInventory.h
@@ -228,7 +228,7 @@ struct UnitInventory {
     void drawAllWorkerTasks() const;
     void drawAllLocations() const;
     void drawAllLastSeens() const;
-    void drawAllMisplacedGroundUnits() const;
+
     UnitInventory getInventoryAtArea(const int areaID) const;
     UnitInventory getCombatInventoryAtArea(const int areaID) const;
     UnitInventory getBuildingInventoryAtArea(const int areaID) const;

--- a/Source/UnitInventory.h
+++ b/Source/UnitInventory.h
@@ -31,7 +31,7 @@ struct StoredUnit {
     StoredUnit(const Unit &unit);
     StoredUnit();
 
-    void updateFAPvalue(FAP::FAPUnit<StoredUnit*> &fap_unit); //updates a single unit's fap forecast when given the fap unit.
+    void updateFAPvalue(FAP::FAPUnit<StoredUnit*> fap_unit); //updates a single unit's fap forecast when given the fap unit.
     void updateFAPvalueDead(); //Updates the unit in the case of it not surviving the FAP simulation.
     void updateStoredUnit(const Unit &unit);
 
@@ -235,7 +235,7 @@ struct UnitInventory {
     UnitInventory getBuildingInventory() const;
 
 
-    void updatePredictedStatus(const CombatSimulator cs); // updates UI with FAP forecasts. Throws exceptions if something is misaligned.
+    void updatePredictedStatus(bool friendly = true); // updates UI with FAP forecasts. Throws exceptions if something is misaligned.
 
     //Gets a pointer to a stored unit when provided the unit pointer.
     StoredUnit* getStoredUnit(const Unit & u);

--- a/Source/UnitInventory.h
+++ b/Source/UnitInventory.h
@@ -14,7 +14,7 @@
 using namespace std;
 using namespace BWAPI;
 
-// Two dependent structures for this inventory manager, a container of enemy_units and enemy units itself. Intend to add more funtionality to Enemy_Inventory, such as upgrades, etc.  May revisit when I learn about parentage, but ought to function for now.
+//Forward declarations of relevant classes.
 class MapInventory;
 class Reservation;
 class CombatSimulator;
@@ -136,10 +136,10 @@ struct StoredUnit {
     int circumference_remaining_;
 
     Unit bwapi_unit_;
-private:
-    //prevent automatic conversion for any other built-in types such as bool, int, etc
-    template<typename T>
-    operator T () const;
+//private:
+//    //prevent automatic conversion for any other built-in types such as bool, int, etc
+//    template<typename T>
+//    operator T () const;
 };
 
 struct UnitInventory {

--- a/Source/UnitInventory.h
+++ b/Source/UnitInventory.h
@@ -98,7 +98,7 @@ struct StoredUnit {
     StoredUnit(Phase p) : phase_(p) {}
     operator Phase () const { return phase_; }
 
-    bool unitDeadInFuture(const int & numberOfConsecutiveDeadSims) const; // returns true if the unit has a MA forcast that implies it will be alive in X frames.
+    bool unitDeadInFuture(const int & numberOfConsecutiveDeadSims = 4) const; // returns true if the unit has a MA forcast that implies it will be alive in X frames.
 
     //Needed commands for workers.
     void startMine(Stored_Resource &new_resource);

--- a/Source/UnitInventory.h
+++ b/Source/UnitInventory.h
@@ -7,6 +7,7 @@
 #include "ReservationManager.h"
 #include "ResearchInventory.h"
 #include "FAP\FAP\include\FAP.hpp"
+#include "CombatSimulator.h"
 #include <random> // C++ base random is low quality.
 
 using namespace std;
@@ -22,22 +23,14 @@ struct StoredUnit {
     StoredUnit(const UnitType & unittype, const bool &carrierUpgrade = false, const bool &reaverUpgrade = false);
 
     static int getTraditionalWeight(const UnitType unittype, const bool &carrierUpgrade = false, const bool &reaverUpgrade = false);
-    static int getGrownWeight(const UnitType unittype, const bool & carrierUpgrade, const bool & reaverUpgrade);
+    //static int getGrownWeight(const UnitType unittype, const bool & carrierUpgrade, const bool & reaverUpgrade);
 
     // Creates an enemy unit object, an abbreviated version of the original.
     StoredUnit(const Unit &unit);
     StoredUnit();
-    auto convertToFAP(const ResearchInventory &ri); // puts stored unit into the fap type.
-    auto convertToFAPPosition(const Position & chosen_pos, const ResearchInventory &ri, const UpgradeType &upgrade = UpgradeTypes::None, const TechType &tech = TechTypes::None); // puts the stored unit into the fap type... at a specific position
-    auto convertToFAPDisabled(const Position & chosen_pos, const ResearchInventory & ri); // puts the unit in as an immobile unit.
-    auto convertToFAPAnitAir(const Position & chosen_pos, const ResearchInventory & ri); // puts the unit in as an anti-air only tool.
-    auto convertToFAPflying(const Position & chosen_pos, const ResearchInventory & ri);
 
-    static void updateFAPvalue(FAP::FAPUnit<StoredUnit*> &fap_unit); //updates a single unit's fap forecast when given the fap unit.
+    void updateFAPvalue(FAP::FAPUnit<StoredUnit*> &fap_unit); //updates a single unit's fap forecast when given the fap unit.
     void updateFAPvalueDead(); //Updates the unit in the case of it not surviving the FAP simulation.
-
-    static bool unitDeadInFuture(const StoredUnit &unit, const int & number_of_frames_voted_death); // returns true if the unit has a MA forcast that implies it will be alive in X frames.
-
     void updateStoredUnit(const Unit &unit);
 
     // Critical information not otherwise stored.
@@ -103,6 +96,8 @@ struct StoredUnit {
     StoredUnit(Phase p) : phase_(p) {}
     operator Phase () const { return phase_; }
 
+    bool unitDeadInFuture(const int & numberOfConsecutiveDeadSims) const; // returns true if the unit has a MA forcast that implies it will be alive in X frames.
+
     //Needed commands for workers.
     void startMine(Stored_Resource &new_resource);
     void startMine(Unit & new_resource);
@@ -154,8 +149,6 @@ struct UnitInventory {
     //what about their upgrades?
     //Other details?
 
-    static const int half_map_ = 120; // SC Screen size is 680 X 240
-    static std::default_random_engine generator_;  //Will be used to obtain a seed for the random number engine
 
     int stock_fliers_ = 0;
     int stock_ground_units_ = 0;
@@ -240,17 +233,7 @@ struct UnitInventory {
     UnitInventory getBuildingInventory() const;
 
 
-
-    // Several ways to add to FAP models. At specific locations, immobilized, at a random position around their original position, to buildFAP's small combat scenario.
-    void addToFAPatPos(FAP::FastAPproximation<StoredUnit*>& fap_object, const Position pos, const bool friendly, const ResearchInventory &ri); // adds to buildFAP
-    void addDisabledToFAPatPos(FAP::FastAPproximation<StoredUnit*>& fap_object, const Position pos, const bool friendly, const ResearchInventory & ri);
-    void addAntiAirToFAPatPos(FAP::FastAPproximation<StoredUnit*>& fap_object, const Position pos, const bool friendly, const ResearchInventory & ri);
-    void addFlyingToFAPatPos(FAP::FastAPproximation<StoredUnit*>& fap_object, const Position pos, const bool friendly, const ResearchInventory & ri);
-    void addToMCFAP(FAP::FastAPproximation<StoredUnit*>& fap_object, const bool friendly, const ResearchInventory & ri); // adds to MC fap.
-    void addToBuildFAP(FAP::FastAPproximation<StoredUnit*>& fap_object, const bool friendly, const ResearchInventory & ri, const UpgradeType &upgrade = UpgradeTypes::None);// adds to the building combat simulator, friendly side.
-
-
-    void pullFromFAP(vector<FAP::FAPUnit<StoredUnit*>> &FAPunits); // updates UI with FAP forecasts. Throws exceptions if something is misaligned.
+    void updatePredictedStatus(CombatSimulator cs); // updates UI with FAP forecasts. Throws exceptions if something is misaligned.
 
     //Gets a pointer to a stored unit when provided the unit pointer.
     StoredUnit* getStoredUnit(const Unit & u);

--- a/Source/UnitInventory.h
+++ b/Source/UnitInventory.h
@@ -24,7 +24,7 @@ struct StoredUnit {
     //Creates a steryotyped ideal of the unit. For comparisons.
     StoredUnit(const UnitType & unittype, const bool &carrierUpgrade = false, const bool &reaverUpgrade = false);
 
-    static int getTraditionalWeight(const UnitType unittype, const bool &carrierUpgrade = false, const bool &reaverUpgrade = false);
+    void setTraditionalWeights(const UnitType unittype, const bool &carrierUpgrade = false, const bool &reaverUpgrade = false);
     //static int getGrownWeight(const UnitType unittype, const bool & carrierUpgrade, const bool & reaverUpgrade);
 
     // Creates an enemy unit object, an abbreviated version of the original.
@@ -248,8 +248,6 @@ struct UnitInventory {
     Position getStrongestLocation() const; //in progress
     Position getMeanCombatLocation() const;
     Position getMeanArmyLocation() const;
-    static Position positionMCFAP(const StoredUnit & su);
-    static Position positionBuildFap(const bool friendly);
     //Position getClosestMeanArmyLocation() const;
 
     void printUnitInventory(const Player &player, const string &bonus = "");

--- a/Source/WorkerManager.h
+++ b/Source/WorkerManager.h
@@ -13,6 +13,13 @@ private:
     int workers_overstacked_; // How many workers are piled on a resource (more than 2x?)
     bool excess_gas_capacity_; // Do we have slots for workers in an extractor?
 
+    // Need to run these every frame.
+    void updateGas_Workers();     // Updates the count of our gas workers.
+    void updateMin_Workers();     // Updates the count of our min workers. 
+    void updateWorkersLongDistanceMining();     // Updates the count of mining workers
+    void updateWorkersOverstacked();     //Updates the count of overstacked workers.
+    void updateExcessCapacity();    // Updates the if gas has excess capacity. NOTE: Does not check if we WANT that capacity atm.
+
 public:
 
     bool workerWork(const Unit &u);     // Do worker things. MAIN LOOP.
@@ -21,29 +28,25 @@ public:
     bool attachToNearestMine(ResourceInventory & ri, StoredUnit & miner);     // attaches the miner to the nearest mine in the inventory, and updates the stored_unit. Returns true on success.
     void attachToParticularMine(Stored_Resource &mine, ResourceInventory &ri, StoredUnit &miner);     // attaches the miner to the particular mine and updates the stored unit.
     void attachToParticularMine(Unit & mine, ResourceInventory & ri, StoredUnit & miner);     // Overload: attaches the miner to the particular mine and updates the stored unit.
-    bool checkBlockingMinerals(const Unit & unit, UnitInventory & ui);     // Returns true if there is a blocking mineral nearby.
-    bool checkGasDump();     //Returns True if there is an endless dumping place for gas. Does not consider all possible gas outlets.
-    bool checkGasOutlet();     //Returns True if there is an out for gas.
-    bool isEmptyWorker(const Unit & unit);     // Checks if unit is carrying minerals.
+    bool checkBlockingMinerals(const Unit & unit, UnitInventory & ui) const;     // Returns true if there is a blocking mineral nearby.
+    bool checkGasDump() const;     //Returns True if there is an endless dumping place for gas. Does not consider all possible gas outlets.
+    bool checkGasOutlet() const;     //Returns True if there is an out for gas.
+    bool isEmptyWorker(const Unit & unit) const;     // Checks if unit is carrying minerals.
     bool workerPrebuild(const Unit & unit);     //Workers at their end build location should build there!  May return false if there is an object at the end destination that prohibits building.
     bool workersCollect(const Unit & unit, const int max_dist);     // Workers doing nothing should begin a resource task. Max_dist represents the longest a worker should be transfered.
     bool workersClear(const Unit &unit);     // Workers should clear if conditions are met;  Ought to be reprogrammed to run a periodic cycle to check for clearing. Then grab nearest worker to patch and assign. This policy may lead to inefficent mining.
     bool workersReturn(const Unit &unit);     // Workers should return cargo and forget about their original mine.
 
-    // Need to run these every frame.
-    void WorkerManager::updateGas_Workers();     // Updates the count of our gas workers.
-    void WorkerManager::updateMin_Workers();     // Updates the count of our min workers. 
-    void WorkerManager::updateWorkersClearing();     // Updates the count of clearing workers
-    void WorkerManager::updateWorkersLongDistanceMining();     // Updates the count of mining workers
-    void WorkerManager::updateWorkersOverstacked();     //Updates the count of overstacked workers.
-    void WorkerManager::updateExcessCapacity();    // Updates the if gas has excess capacity. NOTE: Does not check if we WANT that capacity atm.
+    void updateWorkersClearing();     // Updates the count of clearing workers
 
     //Getters
-    int getGasWorkers(); // how many have the explicit order gathering gas or have gas in their mouths?
-    int getMinWorkers(); // how many have the explicit order gather minerals or have minerals in their mouths?
-    bool checkExcessGasCapacity(); //returns if we have excess gas capacity.
-    int getDistanceWorkers(); //returns the number of distance miners.
-    int getOverstackedWorkers(); //returns the number of distance miners.
+    int getGasWorkers() const; // how many have the explicit order gathering gas or have gas in their mouths?
+    int getMinWorkers() const; // how many have the explicit order gather minerals or have minerals in their mouths?
+    bool checkExcessGasCapacity() const; //returns if we have excess gas capacity.
+    int getDistanceWorkers() const; //returns the number of distance miners.
+    int getOverstackedWorkers() const; //returns the number of distance miners.
 
+    //onFrame
+    void onFrame(); //Performs the 1x per frame update of workers.
 };
 

--- a/TechManager.cpp
+++ b/TechManager.cpp
@@ -40,13 +40,10 @@ void TechManager::updateOptimalTech() {
         // should only upgrade if units for that upgrade exist on the field for me. Or reset every time a new upgrade is found. Need a baseline null upgrade- Otherwise we'll upgrade things like range damage with only lings, when we should be saving for carapace.
         if (!checkUpgradeFull(potential_up.first) && canUpgradeCUNY(potential_up.first) && CUNYAIModule::countUnitsAvailableToPerform(potential_up.first) > 0 || potential_up.first == UpgradeTypes::None) {
             // Add units into relevant simulation.
-            FAP::FastAPproximation<StoredUnit*> upgradeFAP; 
-            CUNYAIModule::friendly_player_model.units_.addToBuildFAP(upgradeFAP, true, CUNYAIModule::friendly_player_model.researches_, potential_up.first);
-            CUNYAIModule::enemy_player_model.units_.addToBuildFAP(upgradeFAP, false, CUNYAIModule::enemy_player_model.researches_);
-
-            upgradeFAP.simulate(FAP_SIM_DURATION); // a complete simulation cannot always be ran... medics & firebats vs air causes a lockup.
-            int score = CUNYAIModule::getFAPScore(upgradeFAP, true) - CUNYAIModule::getFAPScore(upgradeFAP, false);
-            upgradeFAP.clear();
+            CombatSimulator upgradeSim;
+            upgradeSim.addPlayersToMiniSimulation(potential_up.first);
+            upgradeSim.runSimulation();
+            int score = upgradeSim.getScoreGap();
             evaluateWeightsFor(potential_up.first);
             potential_up.second = static_cast<int>( ((24.0 * 20.0 - 1) * upgrade_cycle_[potential_up.first] + score) / (24.0 * 20.0) ); //moving average over 24*20 * 1 simulations. Long because the asymtotics really do not take hold easily.
         }

--- a/UnitInventory.cpp
+++ b/UnitInventory.cpp
@@ -1017,24 +1017,22 @@ void UnitInventory::updatePredictedStatus(bool friendly)
         u.second.updated_fap_this_frame_ = false;
     }
 
-    for (auto &u : unit_map_) {
-        if (friendly) {
-            for (auto fu : CUNYAIModule::mainCombatSim.getFriendlySim()) {
-                if (fu.data) {
-                    u.second.updateFAPvalue(fu);
-                    u.second.updated_fap_this_frame_ = true;
-                }
-            }
-        }
-        else {
-            for (auto fu : CUNYAIModule::mainCombatSim.getEnemySim()) {
-                if (fu.data) {
-                    u.second.updateFAPvalue(fu);
-                    u.second.updated_fap_this_frame_ = true;
-                }
+    //This section takes advantage of the fact that the fap units store the pointers themselves. This way we don't have to do a n^2 lookup. We just look at the fu and directly adjust the pointer.
+    if (friendly) {
+        for (auto fu : CUNYAIModule::mainCombatSim.getFriendlySim()) {
+            if (fu.data) {
+                fu.data->updateFAPvalue(fu);
             }
         }
     }
+    else {
+        for (auto fu : CUNYAIModule::mainCombatSim.getEnemySim()) {
+            if (fu.data) {
+                fu.data->updateFAPvalue(fu);
+            }
+        }
+    }
+
 
     for (auto &u : unit_map_) {
         if (!u.second.updated_fap_this_frame_) { u.second.updateFAPvalueDead(); }

--- a/UnitInventory.cpp
+++ b/UnitInventory.cpp
@@ -982,11 +982,10 @@ bool StoredUnit::isLongRangeLock() {
 
 void StoredUnit::updateFAPvalue(FAP::FAPUnit<StoredUnit*> fap_unit)
 {
+    double proportion_anticipated_health = (fap_unit.health + fap_unit.shields) / static_cast<double>(fap_unit.maxHealth + fap_unit.maxShields);
 
-    double proportion_health = (fap_unit.health + fap_unit.shields) / static_cast<double>(fap_unit.maxHealth + fap_unit.maxShields);
-    fap_unit.data->future_fap_value_ = static_cast<int>(fap_unit.data->stock_value_ * proportion_health);
-
-    fap_unit.data->updated_fap_this_frame_ = true;
+    future_fap_value_ = static_cast<int>(stock_value_ * proportion_anticipated_health);
+    updated_fap_this_frame_ = true;
 }
 
 void StoredUnit::updateFAPvalueDead()
@@ -1006,6 +1005,7 @@ void UnitInventory::updatePredictedStatus(bool friendly)
         for (auto fu : CUNYAIModule::mainCombatSim.getFriendlySim()) {
             if (fu.data) {
                 fu.data->updateFAPvalue(fu);
+                Diagnostics::drawCircle(fu.data->pos_, Broodwar->getScreenPosition(), (fu.data->type_.dimensionUp() + fu.data->type_.dimensionLeft()) / 2, Colors::Cyan); // Plot their last known position.
             }
         }
     }

--- a/UnitInventory.cpp
+++ b/UnitInventory.cpp
@@ -996,7 +996,7 @@ bool StoredUnit::isLongRangeLock() {
     return bwapi_unit_ && target_mine && target_mine->pos_ && (!Broodwar->isVisible(TilePosition(target_mine->pos_)) /*|| (target_mine->bwapi_unit_ && target_mine->bwapi_unit_->isMorphing())*/);
 }
 
-void StoredUnit::updateFAPvalue(FAP::FAPUnit<StoredUnit*> &fap_unit)
+void StoredUnit::updateFAPvalue(FAP::FAPUnit<StoredUnit*> fap_unit)
 {
 
     double proportion_health = (fap_unit.health + fap_unit.shields) / static_cast<double>(fap_unit.maxHealth + fap_unit.maxShields);
@@ -1011,19 +1011,27 @@ void StoredUnit::updateFAPvalueDead()
     updated_fap_this_frame_ = true;
 }
 
-void UnitInventory::updatePredictedStatus(const CombatSimulator cs)
+void UnitInventory::updatePredictedStatus(bool friendly)
 {
     for (auto &u : unit_map_) {
         u.second.updated_fap_this_frame_ = false;
     }
 
-
-    for (auto fu : cs.getEnemySim()) {
-        if (fu.data) {
-            StoredUnit::updateFAPvalue(fu);
+    if (friendly) {
+        for (auto fu : CUNYAIModule::mainCombatSim.getFriendlySim()) {
+            if (fu.data) {
+                StoredUnit::updateFAPvalue(fu);
+            }
         }
     }
-
+    else {
+        for (auto fu : CUNYAIModule::mainCombatSim.getEnemySim()) {
+            if (fu.data) {
+                StoredUnit::updateFAPvalue(fu);
+            }
+        }
+    }
+}
     for (auto &u : unit_map_) {
         if (!u.second.updated_fap_this_frame_) { u.second.updateFAPvalueDead(); }
     }

--- a/UnitInventory.cpp
+++ b/UnitInventory.cpp
@@ -191,20 +191,20 @@ void UnitInventory::drawAllWorkerTasks() const
     for (auto u : unit_map_) {
         if (u.second.type_ == UnitTypes::Zerg_Drone) {
             if (u.second.locked_mine_ && !u.second.isAssignedResource() && !u.second.isAssignedClearing()) {
-                Diagnostics::drawLine(u.second.pos_, u.second.locked_mine_->getPosition(), CUNYAIModule::currentMapInventory.screen_position_, Colors::White);
+                Diagnostics::drawLine(u.second.pos_, u.second.locked_mine_->getPosition(), Broodwar->getScreenPosition(), Colors::White);
             }
             else if (u.second.isAssignedMining()) {
-                Diagnostics::drawLine(u.second.pos_, u.second.locked_mine_->getPosition(), CUNYAIModule::currentMapInventory.screen_position_, Colors::Green);
+                Diagnostics::drawLine(u.second.pos_, u.second.locked_mine_->getPosition(), Broodwar->getScreenPosition(), Colors::Green);
             }
             else if (u.second.isAssignedGas()) {
-                Diagnostics::drawLine(u.second.pos_, u.second.locked_mine_->getPosition(), CUNYAIModule::currentMapInventory.screen_position_, Colors::Brown);
+                Diagnostics::drawLine(u.second.pos_, u.second.locked_mine_->getPosition(), Broodwar->getScreenPosition(), Colors::Brown);
             }
             else if (u.second.isAssignedClearing()) {
-                Diagnostics::drawLine(u.second.pos_, u.second.locked_mine_->getPosition(), CUNYAIModule::currentMapInventory.screen_position_, Colors::Blue);
+                Diagnostics::drawLine(u.second.pos_, u.second.locked_mine_->getPosition(), Broodwar->getScreenPosition(), Colors::Blue);
             }
 
             if (u.second.isAssignedBuilding()) {
-                Diagnostics::drawDot(u.second.pos_, CUNYAIModule::currentMapInventory.screen_position_, Colors::Purple);
+                Diagnostics::drawDot(u.second.pos_, Broodwar->getScreenPosition(), Colors::Purple);
             }
         }
     }
@@ -215,10 +215,10 @@ void UnitInventory::drawAllLocations() const
 {
     for (auto e = unit_map_.begin(); e != unit_map_.end() && !unit_map_.empty(); e++) {
         if (e->second.valid_pos_) {
-            Diagnostics::drawCircle(e->second.pos_, CUNYAIModule::currentMapInventory.screen_position_, (e->second.type_.dimensionUp() + e->second.type_.dimensionLeft()) / 2, Colors::Red); // Plot their last known position.
+            Diagnostics::drawCircle(e->second.pos_, Broodwar->getScreenPosition(), (e->second.type_.dimensionUp() + e->second.type_.dimensionLeft()) / 2, Colors::Red); // Plot their last known position.
         }
         else if (!e->second.valid_pos_) {
-            Diagnostics::drawCircle(e->second.pos_, CUNYAIModule::currentMapInventory.screen_position_, (e->second.type_.dimensionUp() + e->second.type_.dimensionLeft()) / 2, Colors::Blue); // Plot their last known position.
+            Diagnostics::drawCircle(e->second.pos_, Broodwar->getScreenPosition(), (e->second.type_.dimensionUp() + e->second.type_.dimensionLeft()) / 2, Colors::Blue); // Plot their last known position.
         }
 
     }

--- a/UnitInventory.cpp
+++ b/UnitInventory.cpp
@@ -984,9 +984,6 @@ void StoredUnit::updateFAPvalue(FAP::FAPUnit<StoredUnit*> fap_unit)
 {
     double proportion_anticipated_health = (fap_unit.health + fap_unit.shields) / static_cast<double>(fap_unit.maxHealth + fap_unit.maxShields);
 
-    if(type_ == UnitTypes::Zerg_Zergling || bwapi_unit_->getType().getRace() != Races::Zerg)
-        Diagnostics::writeMap(pos_, "HP: " + to_string(proportion_anticipated_health) + "% value:" + to_string(stock_value_) );
-
     this->future_fap_value_ = static_cast<int>(stock_value_ * proportion_anticipated_health);
     this->updated_fap_this_frame_ = true;
 }
@@ -997,7 +994,7 @@ void StoredUnit::updateFAPvalueDead()
     updated_fap_this_frame_ = true;
 }
 
-void UnitInventory::updatePredictedStatus(bool friendly)
+void UnitInventory::updateWithPredictedStatus(CombatSimulator sim, bool friendly)
 {
     //None of them have been updated this frame yet.
     for (auto &u : unit_map_) {
@@ -1008,14 +1005,14 @@ void UnitInventory::updatePredictedStatus(bool friendly)
     //Now update every single unit.
     //This section takes advantage of the fact that the fap units store the pointers themselves. This way we don't have to do a n^2 lookup. We just look at the fu and directly adjust the pointer.
     if (friendly) {
-        for (auto &fu : CUNYAIModule::mainCombatSim.getFriendlySim()) {
+        for (auto &fu : sim.getFriendlySim()) {
             if (fu.data) {
                 fu.data->updateFAPvalue(fu);
             }
         }
     }
     else {
-        for (auto &fu : CUNYAIModule::mainCombatSim.getEnemySim()) {
+        for (auto &fu : sim.getEnemySim()) {
             if (fu.data) {
                 fu.data->updateFAPvalue(fu);
             }

--- a/UnitInventory.cpp
+++ b/UnitInventory.cpp
@@ -1017,21 +1017,25 @@ void UnitInventory::updatePredictedStatus(bool friendly)
         u.second.updated_fap_this_frame_ = false;
     }
 
-    if (friendly) {
-        for (auto fu : CUNYAIModule::mainCombatSim.getFriendlySim()) {
-            if (fu.data) {
-                StoredUnit::updateFAPvalue(fu);
+    for (auto &u : unit_map_) {
+        if (friendly) {
+            for (auto fu : CUNYAIModule::mainCombatSim.getFriendlySim()) {
+                if (fu.data) {
+                    u.second.updateFAPvalue(fu);
+                    u.second.updated_fap_this_frame_ = true;
+                }
+            }
+        }
+        else {
+            for (auto fu : CUNYAIModule::mainCombatSim.getEnemySim()) {
+                if (fu.data) {
+                    u.second.updateFAPvalue(fu);
+                    u.second.updated_fap_this_frame_ = true;
+                }
             }
         }
     }
-    else {
-        for (auto fu : CUNYAIModule::mainCombatSim.getEnemySim()) {
-            if (fu.data) {
-                StoredUnit::updateFAPvalue(fu);
-            }
-        }
-    }
-}
+
     for (auto &u : unit_map_) {
         if (!u.second.updated_fap_this_frame_) { u.second.updateFAPvalueDead(); }
     }

--- a/UnitInventory.cpp
+++ b/UnitInventory.cpp
@@ -1027,7 +1027,7 @@ void UnitInventory::updatePredictedStatus(const CombatSimulator cs)
     for (auto &u : unit_map_) {
         if (!u.second.updated_fap_this_frame_) { u.second.updateFAPvalueDead(); }
     }
-    vector<FAP::FAPUnit<StoredUnit*>> &fap_vector
+    //vector<FAP::FAPUnit<StoredUnit*>> &fap_vector
 }
 
 StoredUnit* UnitInventory::getStoredUnit(const Unit & unit)

--- a/UnitInventory.cpp
+++ b/UnitInventory.cpp
@@ -1011,7 +1011,7 @@ void StoredUnit::updateFAPvalueDead()
     updated_fap_this_frame_ = true;
 }
 
-void UnitInventory::updatePredictedStatus(CombatSimulator cs)
+void UnitInventory::updatePredictedStatus(const CombatSimulator cs)
 {
     for (auto &u : unit_map_) {
         u.second.updated_fap_this_frame_ = false;

--- a/UnitInventory.cpp
+++ b/UnitInventory.cpp
@@ -233,22 +233,6 @@ void UnitInventory::drawAllLastSeens() const
     }
 }
 
-//Marks as red if it's on a minitile that ground units should not be at.
-void UnitInventory::drawAllMisplacedGroundUnits() const
-{
-    if constexpr (DIAGNOSTIC_MODE) {
-        for (auto e = unit_map_.begin(); e != unit_map_.end() && !unit_map_.empty(); e++) {
-            if (CUNYAIModule::isOnScreen(e->second.pos_, CUNYAIModule::currentMapInventory.screen_position_) && !e->second.type_.isBuilding()) {
-                if (CUNYAIModule::currentMapInventory.unwalkable_barriers_with_buildings_[WalkPosition(e->second.pos_).x][WalkPosition(e->second.pos_).y] == 1) {
-                    Broodwar->drawCircleMap(e->second.pos_, (e->second.type_.dimensionUp() + e->second.type_.dimensionLeft()) / 2, Colors::Red, true); // Mark as RED if not in a walkable spot.
-                }
-                else if (CUNYAIModule::currentMapInventory.unwalkable_barriers_with_buildings_[WalkPosition(e->second.pos_).x][WalkPosition(e->second.pos_).y] == 0) {
-                    Broodwar->drawCircleMap(e->second.pos_, (e->second.type_.dimensionUp() + e->second.type_.dimensionLeft()) / 2, Colors::Blue, true); // Mark as RED if not in a walkable spot.
-                }
-            }
-        }
-    }
-}
 
 // Updates the count of units.
 bool UnitInventory::addStoredUnit(const Unit &unit) {

--- a/Utilities.cpp
+++ b/Utilities.cpp
@@ -1757,12 +1757,6 @@ double CUNYAIModule::bindBetween(double x, double lower_bound, double upper_boun
 //Chitinous_Plating = 52,
 //Anabolic_Synthesis = 53,
 
-//Some safety checks if it can't find FAP objects, say at game start.
-int CUNYAIModule::getFAPScore(FAP::FastAPproximation<StoredUnit*> &fap, bool friendly_player) {
-    if (friendly_player && fap.getState().first && !fap.getState().first->empty())                       return std::accumulate(fap.getState().first->begin(), fap.getState().first->end(), 0,   [](int currentScore, auto FAPunit) { return static_cast<int>(currentScore + FAPunit.data->stock_value_ * static_cast<double>(FAPunit.health + FAPunit.shields) / static_cast<double>(FAPunit.maxHealth + FAPunit.maxShields)); });
-    else if(!friendly_player && fap.getState().second && !fap.getState().second->empty())                return std::accumulate(fap.getState().second->begin(), fap.getState().second->end(), 0, [](int currentScore, auto FAPunit) { return static_cast<int>(currentScore + FAPunit.data->stock_value_ * static_cast<double>(FAPunit.health + FAPunit.shields) / static_cast<double>(FAPunit.maxHealth + FAPunit.maxShields)); });
-    else return 0;
-}
 
 //bool CUNYAIModule::checkSuperiorFAPForecast(const UnitInventory &ui, const UnitInventory &ei) {
 //    return  //((ui.stock_fighting_total_ - ui.moving_average_fap_stock_) * ei.stock_fighting_total_ < (ei.stock_fighting_total_ - ei.moving_average_fap_stock_) * ui.stock_fighting_total_ && ui.squadAliveinFuture(24)) || // Proportional win. fixed division by crossmultiplying. Added squadalive in future so the bot is more reasonable in combat situations.

--- a/Utilities.cpp
+++ b/Utilities.cpp
@@ -1564,127 +1564,127 @@ int CUNYAIModule::getChargableDistance(const Unit & u)
 }
 
 
-//finds nearest choke or best location within 100 minitiles.
-Position CUNYAIModule::getNearestChoke( const Position &initial, const Position &final, const MapInventory &inv ) {
-    WalkPosition e_position = WalkPosition( final );
-    WalkPosition wk_postion = WalkPosition( initial );
-    WalkPosition map_dim = WalkPosition( TilePosition( { Broodwar->mapWidth(), Broodwar->mapHeight() } ) );
-
-    int max_observed = CUNYAIModule::currentMapInventory.map_veins_[wk_postion.x][wk_postion.y];
-    Position nearest_choke; 
-
-    for ( auto i = 0; i < 100; ++i ) {
-        for ( int x = -1; x <= 1; ++x ) {
-            for ( int y = -1; y <= 1; ++y ) {
-
-                int testing_x = wk_postion.x + x;
-                int testing_y = wk_postion.y + y;
-
-                if ( !(x == 0, y == 0) &&
-                    testing_x < map_dim.x &&
-                    testing_y < map_dim.y &&
-                    testing_x > 0 &&
-                    testing_y > 0 ) { // check for being within reference space.
-
-                    int temp = CUNYAIModule::currentMapInventory.map_veins_[testing_x][testing_y];
-
-                    if ( temp >= max_observed ) {
-                        max_observed = temp;
-                        nearest_choke = Position( testing_x, testing_y ); //this is our best guess of a choke.
-                        wk_postion = WalkPosition( nearest_choke ); //search from there.
-                        if ( max_observed > 175 ) {
-                            return nearest_choke;
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    //another attempt
-    //int x_dist_to_e = e_position.x - wk_postion.x;
-    //int y_dist_to_e = e_position.y - wk_postion.y;
-
-    //int dx = x_dist_to_e > 0 ? 1 : -1;
-    //int dy = y_dist_to_e > 0 ? 1 : -1;
-
-    //for ( auto i = 0; i < 50; ++i ) {
-    //    for ( int x = 0; x <= 1; ++x ) {
-    //        for ( int y = 0; y <= 1; ++y ) {
-
-    //            int testing_x = wk_postion.x + x * dx;
-    //            int testing_y = wk_postion.y + y * dy;
-
-    //            if ( !(x == 0, y == 0) &&
-    //                testing_x < map_dim.x &&
-    //                testing_y < map_dim.y &&
-    //                testing_x > 0 &&
-    //                testing_y > 0 ) { // check for being within reference space.
-
-    //                int temp = inv.map_veins_[testing_x][testing_y];
-
-    //                if ( temp > max_observed ) {
-    //                    max_observed = temp;
-    //                    nearest_choke = Position( testing_x, testing_y ); //this is our best guess of a choke.
-    //                    wk_postion = WalkPosition( nearest_choke ); //search from there.
-    //                    if ( max_observed > 275 ) {
-    //                        return nearest_choke;
-    //                        break;
-    //                    }
-    //                }
-    //                else if ( y_dist_to_e == 0 || abs( x_dist_to_e / y_dist_to_e ) > 1 ) {
-    //                    dx = x_dist_to_e > 0 ? 1 : -1;
-    //                }
-    //                else {
-    //                    dy = y_dist_to_e > 0 ? 1 : -1;
-    //                }
-    //            }
-    //        }
-    //    }
-    //}
-     //another attempt
-    //int x_dist_to_e, y_dist_to_e, dx, dy, x_inc, y_inc;
-
-    //dx = x_dist_to_e > 0 ? 1 : -1;
-    //dy = y_dist_to_e > 0 ? 1 : -1;
-
-    //for ( auto i = 0; i < 50; ++i ) {
-
-    //    x_dist_to_e = e_position.x - wk_postion.x;
-    //    y_dist_to_e = e_position.y - wk_postion.y;
-
-    //    int testing_x = wk_postion.x + dx;
-    //    int testing_y = wk_postion.y + dy;
-
-    //    if ( testing_x < map_dim.x &&
-
-    //        testing_y < map_dim.y &&
-    //        testing_x > 0 &&
-    //        testing_y > 0 ) { // check for being within reference space.
-
-    //        int temp = inv.map_veins_[testing_x][testing_y];
-
-    //        if ( temp > max_observed ) {
-    //            max_observed = temp;
-    //            nearest_choke = Position( testing_x, testing_y ); //this is our best guess of a choke.
-    //            wk_postion = WalkPosition( nearest_choke ); //search from there.
-    //            if ( max_observed > 275 ) {
-    //                return nearest_choke;
-    //                break;
-    //            }
-    //        }
-    //        else if ( abs(y_dist_to_e / x_dist_to_e) < 1 ) {
-    //            dx += x_dist_to_e > 0 ? 1 : -1;
-    //        }
-    //        else {
-    //            dy += y_dist_to_e > 0 ? 1 : -1;
-    //        }
-    //    }
-    //}
-
-    return nearest_choke;
-}
+////finds nearest choke or best location within 100 minitiles.
+//Position CUNYAIModule::getNearestChoke( const Position &initial, const Position &final, const MapInventory &inv ) {
+//    WalkPosition e_position = WalkPosition( final );
+//    WalkPosition wk_postion = WalkPosition( initial );
+//    WalkPosition map_dim = WalkPosition( TilePosition( { Broodwar->mapWidth(), Broodwar->mapHeight() } ) );
+//
+//    int max_observed = CUNYAIModule::currentMapInventory.map_veins_[wk_postion.x][wk_postion.y];
+//    Position nearest_choke; 
+//
+//    for ( auto i = 0; i < 100; ++i ) {
+//        for ( int x = -1; x <= 1; ++x ) {
+//            for ( int y = -1; y <= 1; ++y ) {
+//
+//                int testing_x = wk_postion.x + x;
+//                int testing_y = wk_postion.y + y;
+//
+//                if ( !(x == 0, y == 0) &&
+//                    testing_x < map_dim.x &&
+//                    testing_y < map_dim.y &&
+//                    testing_x > 0 &&
+//                    testing_y > 0 ) { // check for being within reference space.
+//
+//                    int temp = CUNYAIModule::currentMapInventory.map_veins_[testing_x][testing_y];
+//
+//                    if ( temp >= max_observed ) {
+//                        max_observed = temp;
+//                        nearest_choke = Position( testing_x, testing_y ); //this is our best guess of a choke.
+//                        wk_postion = WalkPosition( nearest_choke ); //search from there.
+//                        if ( max_observed > 175 ) {
+//                            return nearest_choke;
+//                            break;
+//                        }
+//                    }
+//                }
+//            }
+//        }
+//    }
+//
+//    //another attempt
+//    //int x_dist_to_e = e_position.x - wk_postion.x;
+//    //int y_dist_to_e = e_position.y - wk_postion.y;
+//
+//    //int dx = x_dist_to_e > 0 ? 1 : -1;
+//    //int dy = y_dist_to_e > 0 ? 1 : -1;
+//
+//    //for ( auto i = 0; i < 50; ++i ) {
+//    //    for ( int x = 0; x <= 1; ++x ) {
+//    //        for ( int y = 0; y <= 1; ++y ) {
+//
+//    //            int testing_x = wk_postion.x + x * dx;
+//    //            int testing_y = wk_postion.y + y * dy;
+//
+//    //            if ( !(x == 0, y == 0) &&
+//    //                testing_x < map_dim.x &&
+//    //                testing_y < map_dim.y &&
+//    //                testing_x > 0 &&
+//    //                testing_y > 0 ) { // check for being within reference space.
+//
+//    //                int temp = inv.map_veins_[testing_x][testing_y];
+//
+//    //                if ( temp > max_observed ) {
+//    //                    max_observed = temp;
+//    //                    nearest_choke = Position( testing_x, testing_y ); //this is our best guess of a choke.
+//    //                    wk_postion = WalkPosition( nearest_choke ); //search from there.
+//    //                    if ( max_observed > 275 ) {
+//    //                        return nearest_choke;
+//    //                        break;
+//    //                    }
+//    //                }
+//    //                else if ( y_dist_to_e == 0 || abs( x_dist_to_e / y_dist_to_e ) > 1 ) {
+//    //                    dx = x_dist_to_e > 0 ? 1 : -1;
+//    //                }
+//    //                else {
+//    //                    dy = y_dist_to_e > 0 ? 1 : -1;
+//    //                }
+//    //            }
+//    //        }
+//    //    }
+//    //}
+//     //another attempt
+//    //int x_dist_to_e, y_dist_to_e, dx, dy, x_inc, y_inc;
+//
+//    //dx = x_dist_to_e > 0 ? 1 : -1;
+//    //dy = y_dist_to_e > 0 ? 1 : -1;
+//
+//    //for ( auto i = 0; i < 50; ++i ) {
+//
+//    //    x_dist_to_e = e_position.x - wk_postion.x;
+//    //    y_dist_to_e = e_position.y - wk_postion.y;
+//
+//    //    int testing_x = wk_postion.x + dx;
+//    //    int testing_y = wk_postion.y + dy;
+//
+//    //    if ( testing_x < map_dim.x &&
+//
+//    //        testing_y < map_dim.y &&
+//    //        testing_x > 0 &&
+//    //        testing_y > 0 ) { // check for being within reference space.
+//
+//    //        int temp = inv.map_veins_[testing_x][testing_y];
+//
+//    //        if ( temp > max_observed ) {
+//    //            max_observed = temp;
+//    //            nearest_choke = Position( testing_x, testing_y ); //this is our best guess of a choke.
+//    //            wk_postion = WalkPosition( nearest_choke ); //search from there.
+//    //            if ( max_observed > 275 ) {
+//    //                return nearest_choke;
+//    //                break;
+//    //            }
+//    //        }
+//    //        else if ( abs(y_dist_to_e / x_dist_to_e) < 1 ) {
+//    //            dx += x_dist_to_e > 0 ? 1 : -1;
+//    //        }
+//    //        else {
+//    //            dy += y_dist_to_e > 0 ? 1 : -1;
+//    //        }
+//    //    }
+//    //}
+//
+//    return nearest_choke;
+//}
 
 // checks if a location is safe and doesn't block minerals.
 bool CUNYAIModule::checkSafeBuildLoc(const Position pos) {


### PR DESCRIPTION
This patch is part of a larger refactor. 

1) It removes combat simulators from scattered calls to a separate class that acts as a wrapper for FAP.  
They are called and then move out of scope.

2) It improves 2 diagnostic functions: a) DiagnosticBar - which draws a segmented bar (like HP) of arbitrary color under a particular unit.  b) DiagnosticClock which tells me if a particular function or code segment runs over 15ms.

3) I pull several lines of code out of onFrame() and shift towards McRave's style of each class having an independent thisClass.onFrame() call.  

It contains 1 play style change - altering the retreating patterns to a shorter, more concise definition. It reduces performance against some bots.